### PR TITLE
More readable, linter-style validation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ astralint lint myfile.cdf --suite ISTP --select "ISTP-MD-003" --select ".*Global
 # Ignore specific rules by reference ID or name, regex supported
 astralint lint myfile.cdf --suite ISTP --ignore "ISTP-MD-00[0-9]" --ignore "MandatoryGlobalAttributes"
 
+# Show only failed assertions (hide passed and skipped)
+astralint lint myfile.cdf --failed-only
+
 # List available suites
 astralint list-suites
 
@@ -221,7 +224,7 @@ Lists are accessed using numeric indices: `path/to/list/0`, `path/to/list/1`, et
 ## Defining Rules in YAML
 
 Rules can be defined declaratively in YAML files. Example from [
-`MandatoryAttributes.yaml`](src/astralint/suites/ISTP/rules/MandatoryAttributes.yaml):
+`MandatoryGlobalAttributes.yaml`](src/astralint/suites/ISTP/rules/GlobalAttributes/MandatoryGlobalAttributes.yaml):
 
 ```yaml
 name: MandatoryGlobalAttributes

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ astralint lint myfile.cdf --suite ISTP --ignore "ISTP-MD-00[0-9]" --ignore "Mand
 # Show every check, including the ones that passed (full tree)
 astralint lint myfile.cdf --show-passed
 
+# Show only failed assertions, pruning passed and skipped from the full tree
+astralint lint myfile.cdf --show-passed --failed-only
+
 # List available suites
 astralint list-suites
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ astralint lint myfile.cdf --suite ISTP --select "ISTP-MD-003" --select ".*Global
 # Ignore specific rules by reference ID or name, regex supported
 astralint lint myfile.cdf --suite ISTP --ignore "ISTP-MD-00[0-9]" --ignore "MandatoryGlobalAttributes"
 
-# Show only failed assertions (hide passed and skipped)
-astralint lint myfile.cdf --failed-only
+# Show every check, including the ones that passed (full tree)
+astralint lint myfile.cdf --show-passed
 
 # List available suites
 astralint list-suites
@@ -57,6 +57,12 @@ astralint list-suites
 # Strict mode: exit with error on warnings too
 astralint lint myfile.cdf --strict
 ```
+
+By default the console output is **quiet**, like a typical linter: it lists only
+the errors and warnings that need attention, sorted by severity, and ends with a
+one-line verdict (e.g. `✗ Found 7 problems (3 errors, 4 warnings), plus 13 info
+findings`). Use `--show-passed` to see the full nested tree of every check, and
+`--output html` for an interactive, filterable report.
 
 AstraLint returns exit code `1` on validation errors (or warnings with `--strict`), making it suitable for CI/CD pipelines.
 

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -554,6 +554,39 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             }
         }
 
+        // Embedded report <script> tags don't run when injected via innerHTML,
+        // so wire up collapse + filtering here after each render.
+        function wireReport() {
+            document.querySelectorAll('.group-header').forEach(header => {
+                header.addEventListener('click', () => {
+                    header.parentElement.classList.toggle('collapsed');
+                });
+            });
+
+            const filterInput = document.getElementById('alr-filter');
+            const failedOnly = document.getElementById('alr-failed-only');
+            if (!filterInput || !failedOnly) return;
+
+            function applyFilter() {
+                const q = filterInput.value.toLowerCase();
+                const onlyFailed = failedOnly.checked;
+                document.querySelectorAll('.alr .result').forEach(r => {
+                    const matchesText = !q || r.textContent.toLowerCase().includes(q);
+                    const matchesState = !onlyFailed || r.classList.contains('invalid');
+                    r.style.display = (matchesText && matchesState) ? '' : 'none';
+                });
+                document.querySelectorAll('.alr .group').forEach(g => {
+                    const visible = [...g.querySelectorAll('.result')]
+                        .some(r => r.style.display !== 'none');
+                    g.style.display = visible ? '' : 'none';
+                    if (visible && (q || onlyFailed)) g.classList.remove('collapsed');
+                });
+            }
+
+            filterInput.addEventListener('input', applyFilter);
+            failedOnly.addEventListener('change', applyFilter);
+        }
+
         // Validate raw bytes. suiteName defaults to the currently-checked radio.
         // Shared by local uploads (processFile) and the postMessage handoff.
         async function validateBytes(uint8Array, name, suiteName) {
@@ -572,12 +605,7 @@ validate_file_bytes(file_bytes.to_py(), file_name, selected_suite)
 
                 results.innerHTML = html;
 
-                // Add click handlers for collapsible groups
-                document.querySelectorAll('.group-header').forEach(header => {
-                    header.addEventListener('click', () => {
-                        header.parentElement.classList.toggle('collapsed');
-                    });
-                });
+                wireReport();
 
             } catch (error) {
                 results.innerHTML = '<div class="status error">✗ Error: ' + error.message + '</div>';
@@ -613,12 +641,7 @@ validate_file_url(file_url, selected_suite)
 
                 results.innerHTML = html;
 
-                // Add click handlers for collapsible groups
-                document.querySelectorAll('.group-header').forEach(header => {
-                    header.addEventListener('click', () => {
-                        header.parentElement.classList.toggle('collapsed');
-                    });
-                });
+                wireReport();
 
             } catch (error) {
                 results.innerHTML = '<div class="status error">✗ Error loading from URL: ' + error.message + '</div>';

--- a/src/astralint/astralint.py
+++ b/src/astralint/astralint.py
@@ -128,6 +128,7 @@ def lint(
     dest: Path | None = None,
     verbose: bool = False,
     show_passed: bool | None = None,
+    failed_only: bool = False,
     strict: bool = False,
 ):
     """Lint the given file or directory against the specified conformance suite.
@@ -152,6 +153,8 @@ def lint(
         Show detailed output including config file used.
     show_passed : bool, optional
         Show passed assertions in the report. Overrides config file.
+    failed_only : bool
+        Show only failed assertions, hiding passed and skipped ones.
     strict : bool
         Exit with error code on warnings too, not just errors.
     """
@@ -223,6 +226,7 @@ def lint(
             output=cfg.output.format,
             dest=cfg.output.dest,
             show_passed=cfg.output.show_passed,
+            failed_only=failed_only,
         )
 
         # Exit with error code if validation failed

--- a/src/astralint/base/validation_result.py
+++ b/src/astralint/base/validation_result.py
@@ -24,6 +24,7 @@ class ValidationResultGroup(BaseModel):
     severity: Severity
     results: "list[ValidationResult | ValidationResultGroup]"
     message: str = ""
+    url: str = ""
 
     def extend(
         self,
@@ -92,6 +93,23 @@ class ValidationResultGroup(BaseModel):
                     kept.append(child)
             else:
                 pruned = child.without_passed()
+                if pruned.results:
+                    kept.append(pruned)
+        return self.model_copy(update={"results": kept})
+
+    def failures_only(self) -> "ValidationResultGroup":
+        """Return a copy of this tree with only failing leaves (``valid`` is False).
+
+        Stricter than ``without_passed``: passed *and* skipped leaves are dropped,
+        and groups left empty are pruned. Matches "show only failed assertions".
+        """
+        kept: list[ValidationResult | ValidationResultGroup] = []
+        for child in self.results:
+            if isinstance(child, ValidationResult):
+                if not child.valid:
+                    kept.append(child)
+            else:
+                pruned = child.failures_only()
                 if pruned.results:
                     kept.append(pruned)
         return self.model_copy(update={"results": kept})

--- a/src/astralint/base/yaml_rules/yaml_rule.py
+++ b/src/astralint/base/yaml_rules/yaml_rule.py
@@ -50,6 +50,7 @@ class YamlRule(Rule):
             rule_reference=self.reference,
             results=results,
             severity=self.severity,
+            url=self.url,
         )
 
 

--- a/src/astralint/config/loader.py
+++ b/src/astralint/config/loader.py
@@ -43,7 +43,7 @@ exclude: []
 output:
   format: console  # console | html | json
   verbose: false
-  show_passed: true
+  # show_passed: true   # console is quiet (failures only) by default; set true to list passing checks
 """
 
 

--- a/src/astralint/config/schema.py
+++ b/src/astralint/config/schema.py
@@ -15,7 +15,8 @@ class OutputConfig(BaseModel):
 
     format: Literal["console", "html", "json"] = "console"
     verbose: bool = False
-    show_passed: bool = True
+    # None = reporter default (console is quiet/failures-only; HTML/JSON stay comprehensive).
+    show_passed: bool | None = None
     dest: Path | None = None
 
 

--- a/src/astralint/reports/__init__.py
+++ b/src/astralint/reports/__init__.py
@@ -10,16 +10,24 @@ _REPORTERS = {
 
 
 def report(
-    results, output="console", dest=None, show_passed: bool = True, failed_only: bool = False
+    results, output="console", dest=None, show_passed: bool | None = None, failed_only: bool = False
 ):
-    """The main entry point called by the CLI."""
-    if failed_only:
-        results = results.failures_only()
-    elif not show_passed:
-        results = results.without_passed()
+    """The main entry point called by the CLI.
+
+    Console output is quiet by default (failures + verdict) and computes its
+    verdict from the full results, so filtering is delegated to it. HTML and
+    JSON stay comprehensive unless explicitly narrowed.
+    """
+    if output == "console":
+        return console_report(results, dest, show_passed=show_passed, failed_only=failed_only)
+
     reporter = _REPORTERS.get(output)
     if reporter is None:
         raise ValueError(
             f"Unknown output format '{output}'. Supported formats: {', '.join(sorted(_REPORTERS))}."
         )
+    if failed_only:
+        results = results.failures_only()
+    elif show_passed is False:
+        results = results.without_passed()
     return reporter(results, dest)

--- a/src/astralint/reports/__init__.py
+++ b/src/astralint/reports/__init__.py
@@ -9,9 +9,13 @@ _REPORTERS = {
 }
 
 
-def report(results, output="console", dest=None, show_passed: bool = True):
+def report(
+    results, output="console", dest=None, show_passed: bool = True, failed_only: bool = False
+):
     """The main entry point called by the CLI."""
-    if not show_passed:
+    if failed_only:
+        results = results.failures_only()
+    elif not show_passed:
         results = results.without_passed()
     reporter = _REPORTERS.get(output)
     if reporter is None:

--- a/src/astralint/reports/console.py
+++ b/src/astralint/reports/console.py
@@ -32,7 +32,10 @@ def _render_result(res: ValidationResult) -> Text:
     )
 
     text = Text.from_markup(f"{icon} [bold]{res.reference}[/]: {escape(res.message)}")
-    text.append(f" ({res.severity.value})", style=f"bold {color}")
+
+    # Severity only muddies passing lines; surface it only when the check failed (#11).
+    if not res.valid:
+        text.append(f" ({res.severity.value})", style=f"bold {color}")
 
     # Show target if it's not the generic 'Global'
     if res.target != "Global":
@@ -51,6 +54,9 @@ def _render_group(group: ValidationResultGroup) -> Tree:
     header = Text.assemble(
         (f" {group.name} ", header_style), (f"[{group.rule_reference}]", "italic dim")
     )
+    if group.url:
+        header.append("\n  ↳ ", style="dim")
+        header.append(group.url, style=f"dim link {group.url}")
 
     tree = Tree(header)
     for item in group.results:

--- a/src/astralint/reports/console.py
+++ b/src/astralint/reports/console.py
@@ -1,3 +1,4 @@
+import re
 from functools import singledispatch
 from pathlib import Path
 
@@ -8,6 +9,15 @@ from rich.text import Text
 from rich.tree import Tree
 
 from ..base import Severity, ValidationResult, ValidationResultGroup
+
+_SEVERITY_COLOR = {
+    Severity.ERROR: "red",
+    Severity.WARNING: "yellow",
+    Severity.INFO: "blue",
+    Severity.SKIPPED: "dim",
+}
+_SEVERITY_RANK = {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2, Severity.SKIPPED: 3}
+_FILE_NAME_RE = re.compile(r"on file '(?P<name>.+)'")
 
 
 @singledispatch
@@ -80,7 +90,123 @@ def console_report(results: ValidationResultGroup, console: Console):
     return console
 
 
-def report(results: ValidationResultGroup, dest: Path | None = None):
-    """The main entry point called by the CLI."""
+def _collect_findings(
+    node: ValidationResult | ValidationResultGroup, code: str, url: str
+) -> list[tuple[ValidationResult, str, str]]:
+    """Flatten the tree into (leaf, rule_code, doc_url), carrying the nearest rule's code/url."""
+    if isinstance(node, ValidationResult):
+        return [(node, node.reference or code, url)]
+    code = node.rule_reference or code
+    url = node.url or url
+    findings: list[tuple[ValidationResult, str, str]] = []
+    for child in node.results:
+        findings.extend(_collect_findings(child, code, url))
+    return findings
+
+
+def _file_sections(
+    results: ValidationResultGroup,
+) -> list[tuple[str | None, ValidationResultGroup]]:
+    """Split the top result group into per-file sections, falling back to a single section."""
+    file_groups = [
+        child
+        for child in results.results
+        if isinstance(child, ValidationResultGroup) and "on file '" in child.name
+    ]
+    if not file_groups:
+        return [(None, results)]
+    sections = []
+    for group in file_groups:
+        match = _FILE_NAME_RE.search(group.name)
+        sections.append((match.group("name") if match else group.name, group))
+    return sections
+
+
+def _plural(n: int, word: str) -> str:
+    return f"{n} {word}{'' if n == 1 else 's'}"
+
+
+def _summary_text(counts: dict[str, int]) -> Text:
+    problems = counts["ERROR"] + counts["WARNING"]
+    info = counts["INFO"]
+    if problems == 0:
+        if info == 0:
+            return Text("✓ All checks passed", style="bold green")
+        return Text(
+            f"✓ No errors or warnings ({_plural(info, 'info finding')})", style="bold green"
+        )
+    parts = [
+        _plural(counts[sev], label)
+        for sev, label in (("ERROR", "error"), ("WARNING", "warning"))
+        if counts[sev] > 0
+    ]
+    text = Text(f"✗ Found {_plural(problems, 'problem')} ({', '.join(parts)})", style="bold red")
+    if info:
+        text.append(f", plus {_plural(info, 'info finding')}", style="blue")
+    return text
+
+
+def _render_finding(leaf: ValidationResult, code: str) -> Text:
+    color = _SEVERITY_COLOR.get(leaf.severity, "white")
+    text = Text(f"  {leaf.severity.value:<8}", style=f"bold {color}")
+    text.append(f"{code}  ", style="dim")
+    if leaf.target and leaf.target != "Global":
+        text.append(f"{leaf.target} › ", style="cyan")
+    text.append(escape(leaf.message))
+    return text
+
+
+_LISTED_SEVERITIES = (Severity.ERROR, Severity.WARNING)
+
+
+def _render_quiet(results: ValidationResultGroup, console: Console):
+    """Linter-style output: a flat, severity-sorted list of errors and warnings plus a verdict.
+
+    INFO findings are kept out of the list (surfaced as a count in the verdict) so the
+    default view stays focused on what needs action; ``--show-passed`` shows everything.
+    """
+    console.print()
+    for filename, group in _file_sections(results):
+        failures = [
+            (leaf, code)
+            for leaf, code, _ in _collect_findings(group, "", "")
+            if not leaf.valid and leaf.severity in _LISTED_SEVERITIES
+        ]
+        if not failures:
+            continue
+        failures.sort(key=lambda f: _SEVERITY_RANK.get(f[0].severity, 99))
+        if filename:
+            console.print(Text(filename, style="bold underline"))
+        for leaf, code in failures:
+            console.print(_render_finding(leaf, code))
+        console.print()
+
+    counts = results.count_by_severity()
+    if counts["INFO"]:
+        console.print(
+            Text(
+                f"  {counts['INFO']} info finding(s) hidden — use --show-passed "
+                "or --output html to see them",
+                style="dim",
+            )
+        )
+    console.print(_summary_text(counts))
+
+
+def report(
+    results: ValidationResultGroup,
+    dest: Path | None = None,
+    show_passed: bool | None = None,
+    failed_only: bool = False,
+):
+    """The main entry point called by the CLI.
+
+    Quiet by default (failures + verdict, linter-style). ``show_passed=True``
+    restores the full nested tree.
+    """
     console = Console()
-    console_report(results, console)
+    if show_passed:
+        console_report(results, console)
+        console.print(_summary_text(results.count_by_severity()))
+    else:
+        _render_quiet(results, console)

--- a/src/astralint/reports/console.py
+++ b/src/astralint/reports/console.py
@@ -47,8 +47,8 @@ def _render_result(res: ValidationResult) -> Text:
     if not res.valid:
         text.append(f" ({res.severity.value})", style=f"bold {color}")
 
-    # Show target if it's not the generic 'Global'
-    if res.target != "Global":
+    # Show target if it's a concrete one (not the generic 'Global' nor an empty target).
+    if res.target and res.target != "Global":
         text.append(f" @ {res.target}", style="italic cyan")
 
     return text
@@ -193,6 +193,14 @@ def _render_quiet(results: ValidationResultGroup, console: Console):
     console.print(_summary_text(counts))
 
 
+def _emit(results: ValidationResultGroup, console: Console, show_passed: bool | None):
+    if show_passed:
+        console_report(results, console)
+        console.print(_summary_text(results.count_by_severity()))
+    else:
+        _render_quiet(results, console)
+
+
 def report(
     results: ValidationResultGroup,
     dest: Path | None = None,
@@ -202,11 +210,15 @@ def report(
     """The main entry point called by the CLI.
 
     Quiet by default (failures + verdict, linter-style). ``show_passed=True``
-    restores the full nested tree.
+    restores the full nested tree; ``failed_only`` prunes passing/skipped leaves
+    even in that tree. With ``dest`` the (uncolored) output is written to a file.
     """
-    console = Console()
-    if show_passed:
-        console_report(results, console)
-        console.print(_summary_text(results.count_by_severity()))
+    if failed_only:
+        results = results.failures_only()
+
+    if dest:
+        with dest.open("w") as fh:
+            _emit(results, Console(file=fh, color_system=None), show_passed)
+        print(f"Report saved to: {dest}")
     else:
-        _render_quiet(results, console)
+        _emit(results, Console(), show_passed)

--- a/src/astralint/reports/html.py
+++ b/src/astralint/reports/html.py
@@ -92,6 +92,35 @@ _REPORT_CSS = """
         .alr .stat.failed .count { color: var(--alr-error); }
         .alr .stat.warnings .count { color: var(--alr-warning); }
 
+        .alr .filter-bar {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .alr .filter-bar input[type="search"] {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.6rem 0.9rem;
+            border: 1px solid var(--alr-border);
+            border-radius: 8px;
+            background: var(--alr-card);
+            color: var(--alr-text);
+            font-size: 0.9rem;
+        }
+
+        .alr .filter-bar .failed-toggle {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-size: 0.875rem;
+            color: var(--alr-text-muted);
+            user-select: none;
+            cursor: pointer;
+        }
+
         .alr .results { background: var(--alr-card); border-radius: 12px; border: 1px solid var(--alr-border); }
 
         .alr .group { border-bottom: 1px solid var(--alr-border); }
@@ -119,6 +148,14 @@ _REPORT_CSS = """
 
         .alr .group-header .name { font-weight: 600; }
         .alr .group-header .ref { color: var(--alr-text-muted); font-size: 0.875rem; }
+
+        .alr .group-header .doc-link {
+            font-size: 0.75rem;
+            color: var(--alr-info);
+            text-decoration: none;
+            white-space: nowrap;
+        }
+        .alr .group-header .doc-link:hover { text-decoration: underline; }
 
         .alr .group-header .badge {
             margin-left: auto;
@@ -202,6 +239,13 @@ _REPORT_BODY = """
             </div>
         </div>
 
+        <div class="filter-bar">
+            <input type="search" id="alr-filter" placeholder="Filter results by text…" autocomplete="off">
+            <label class="failed-toggle">
+                <input type="checkbox" id="alr-failed-only"> Show only failed
+            </label>
+        </div>
+
         <div class="results">
             {{ render_item(results) }}
         </div>
@@ -217,6 +261,25 @@ _REPORT_BODY = """
                 header.parentElement.classList.toggle('collapsed');
             });
         });
+
+        function applyFilter() {
+            const q = document.getElementById('alr-filter').value.toLowerCase();
+            const failedOnly = document.getElementById('alr-failed-only').checked;
+            document.querySelectorAll('.alr .result').forEach(r => {
+                const matchesText = !q || r.textContent.toLowerCase().includes(q);
+                const matchesState = !failedOnly || r.classList.contains('invalid');
+                r.style.display = (matchesText && matchesState) ? '' : 'none';
+            });
+            document.querySelectorAll('.alr .group').forEach(g => {
+                const visible = [...g.querySelectorAll('.result')]
+                    .some(r => r.style.display !== 'none');
+                g.style.display = visible ? '' : 'none';
+                if (visible && (q || failedOnly)) g.classList.remove('collapsed');
+            });
+        }
+
+        document.getElementById('alr-filter').addEventListener('input', applyFilter);
+        document.getElementById('alr-failed-only').addEventListener('change', applyFilter);
     </script>
 """
 
@@ -253,7 +316,7 @@ RESULT_TEMPLATE = """
         <div class="target">@ {{ result.target }}</div>
         {% endif %}
     </div>
-    <span class="severity {{ result.severity.value }}">{{ result.severity.value }}</span>
+    {% if not result.valid %}<span class="severity {{ result.severity.value }}">{{ result.severity.value }}</span>{% endif %}
 </div>
 """
 
@@ -263,6 +326,7 @@ GROUP_TEMPLATE = """
         <span class="arrow">▼</span>
         <span class="name">{{ group.name }}</span>
         {% if group.rule_reference %}<span class="ref">[{{ group.rule_reference }}]</span>{% endif %}
+        {% if group.url %}<a class="doc-link" href="{{ group.url }}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="Open documentation">📖 docs</a>{% endif %}
         <span class="badge {{ 'pass' if all_valid else 'fail' }}">
             {{ 'PASS' if all_valid else 'FAIL' }}
         </span>

--- a/src/astralint/reports/html.py
+++ b/src/astralint/reports/html.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 from jinja2 import Template
+from markupsafe import Markup
 
 from ..base import Severity, ValidationResult, ValidationResultGroup
 
@@ -312,7 +313,7 @@ RESULT_TEMPLATE = """
     <div class="content">
         <span class="reference">{{ result.reference }}</span>: 
         <span class="message">{{ result.message }}</span>
-        {% if result.target != 'Global' %}
+        {% if result.target and result.target != 'Global' %}
         <div class="target">@ {{ result.target }}</div>
         {% endif %}
     </div>
@@ -326,7 +327,7 @@ GROUP_TEMPLATE = """
         <span class="arrow">▼</span>
         <span class="name">{{ group.name }}</span>
         {% if group.rule_reference %}<span class="ref">[{{ group.rule_reference }}]</span>{% endif %}
-        {% if group.url %}<a class="doc-link" href="{{ group.url }}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="Open documentation">📖 docs</a>{% endif %}
+        {% if doc_url %}<a class="doc-link" href="{{ doc_url }}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="Open documentation">📖 docs</a>{% endif %}
         <span class="badge {{ 'pass' if all_valid else 'fail' }}">
             {{ 'PASS' if all_valid else 'FAIL' }}
         </span>
@@ -368,18 +369,33 @@ def _is_all_valid(item: ValidationResult | ValidationResultGroup) -> bool:
     return all(_is_all_valid(child) for child in item.results)
 
 
-def _render_item(item: ValidationResult | ValidationResultGroup) -> str:
-    """Render a single item (result or group) to HTML."""
+def _safe_doc_url(url: str) -> str:
+    """Only allow http(s) links; block javascript:/data: and other schemes."""
+    return url if url.startswith(("http://", "https://")) else ""
+
+
+def _render_item(item: ValidationResult | ValidationResultGroup) -> Markup:
+    """Render a single item (result or group) to HTML.
+
+    Returns Markup so the autoescaping templates inject already-rendered children
+    without re-escaping, while every data field is escaped.
+    """
     if isinstance(item, ValidationResult):
-        template = Template(RESULT_TEMPLATE)
-        return template.render(result=item)
-    else:
-        template = Template(GROUP_TEMPLATE)
-        return template.render(group=item, all_valid=_is_all_valid(item), render_item=_render_item)
+        template = Template(RESULT_TEMPLATE, autoescape=True)
+        return Markup(template.render(result=item))
+    template = Template(GROUP_TEMPLATE, autoescape=True)
+    return Markup(
+        template.render(
+            group=item,
+            all_valid=_is_all_valid(item),
+            render_item=_render_item,
+            doc_url=_safe_doc_url(item.url),
+        )
+    )
 
 
 def _render_report(template_str: str, results: ValidationResultGroup) -> str:
-    template = Template(template_str)
+    template = Template(template_str, autoescape=True)
     stats = _count_stats(results)
     return template.render(
         results=results,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ class TestAstraLintConfig:
         assert cfg.ignore == []
         assert cfg.output.format == "console"
         assert cfg.output.verbose is False
-        assert cfg.output.show_passed is True
+        assert cfg.output.show_passed is None  # None = reporter default (console quiet)
 
     def test_config_with_values(self):
         """Config accepts valid values."""

--- a/tests/test_console_summary.py
+++ b/tests/test_console_summary.py
@@ -146,3 +146,35 @@ class TestHtmlUnaffectedByDefault:
         out = capsys.readouterr().out
         # HTML stays comprehensive (filter box narrows client-side), passing rule present.
         assert "version ok" in out
+
+
+class TestConsoleDestAndFailedOnly:
+    def test_dest_writes_console_output_to_file(self, tmp_path):
+        dest = tmp_path / "report.txt"
+        report(_mixed(), output="console", dest=dest)
+        content = dest.read_text()
+        assert "ISTP-GA-004" in content
+        assert "Found" in content
+
+    def test_failed_only_prunes_tree_even_with_show_passed(self, capsys):
+        report(_mixed(), output="console", show_passed=True, failed_only=True)
+        out = capsys.readouterr().out
+        assert "ISTP-GA-004" in out  # failing rule kept
+        assert "version ok" not in out  # passing leaf pruned despite show_passed
+
+
+class TestTreeEmptyTarget:
+    def test_tree_omits_at_for_empty_target(self, capsys):
+        group = ValidationResultGroup(
+            name="R",
+            rule_reference="R-1",
+            severity=Severity.ERROR,
+            results=[
+                ValidationResult(
+                    valid=False, reference="R-1", severity=Severity.ERROR, message="m", target=""
+                )
+            ],
+        )
+        report(group, output="console", show_passed=True)
+        out = capsys.readouterr().out
+        assert "@ " not in out

--- a/tests/test_console_summary.py
+++ b/tests/test_console_summary.py
@@ -1,0 +1,148 @@
+"""Tests for the linter-style quiet console output: a flat findings list plus a
+verdict/summary line, quiet (failures-only) by default."""
+
+from astralint.base.validation_result import (
+    Severity,
+    ValidationResult,
+    ValidationResultGroup,
+)
+from astralint.reports import report
+
+
+def _file_results(filename: str, *rules: ValidationResultGroup) -> ValidationResultGroup:
+    file_group = ValidationResultGroup(
+        name=f"AstraLint Results for suite 'ISTP' on file '{filename}'",
+        rule_reference="",
+        severity=Severity.INFO,
+        results=list(rules),
+    )
+    return ValidationResultGroup(
+        name="AstraLint Results",
+        rule_reference="",
+        severity=Severity.INFO,
+        results=[file_group],
+    )
+
+
+def _rule(reference: str, severity: Severity, *leaves: ValidationResult) -> ValidationResultGroup:
+    return ValidationResultGroup(
+        name=reference,
+        rule_reference=reference,
+        severity=severity,
+        results=list(leaves),
+    )
+
+
+def _leaf(
+    valid: bool, severity: Severity, message: str, target: str = "Global"
+) -> ValidationResult:
+    return ValidationResult(
+        valid=valid, reference="", severity=severity, message=message, target=target
+    )
+
+
+def _mixed() -> ValidationResultGroup:
+    return _file_results(
+        "my.cdf",
+        _rule(
+            "ISTP-GA-004",
+            Severity.ERROR,
+            _leaf(False, Severity.ERROR, "bad logical_file_id", "Logical_file_id"),
+        ),
+        _rule(
+            "ISTP-GA-005",
+            Severity.WARNING,
+            _leaf(True, Severity.WARNING, "version ok", "Data_version"),
+        ),
+        _rule(
+            "ISTP-GA-010",
+            Severity.WARNING,
+            _leaf(False, Severity.WARNING, "non-standard instrument type", "Instrument_type"),
+        ),
+    )
+
+
+class TestSummaryLine:
+    def test_summary_counts_failures_by_severity(self, capsys):
+        report(_mixed(), output="console")
+        out = capsys.readouterr().out
+        assert "2 problems" in out
+        assert "1 error" in out
+        assert "1 warning" in out
+
+    def test_all_passed_shows_success_verdict(self, capsys):
+        passing = _file_results(
+            "ok.cdf",
+            _rule("ISTP-GA-005", Severity.WARNING, _leaf(True, Severity.WARNING, "ok", "X")),
+        )
+        report(passing, output="console")
+        out = capsys.readouterr().out
+        assert "passed" in out.lower()
+        assert "problem" not in out.lower()
+
+
+class TestQuietDefault:
+    def test_default_hides_passing_findings(self, capsys):
+        report(_mixed(), output="console")
+        out = capsys.readouterr().out
+        assert "ISTP-GA-004" in out  # failing error
+        assert "ISTP-GA-010" in out  # failing warning
+        assert "ISTP-GA-005" not in out  # passing, hidden by default
+
+    def test_default_shows_filename_and_codes(self, capsys):
+        report(_mixed(), output="console")
+        out = capsys.readouterr().out
+        assert "my.cdf" in out
+
+    def test_errors_listed_before_warnings(self, capsys):
+        report(_mixed(), output="console")
+        out = capsys.readouterr().out
+        assert out.index("ISTP-GA-004") < out.index("ISTP-GA-010")
+
+    def test_show_passed_reveals_passing_findings(self, capsys):
+        report(_mixed(), output="console", show_passed=True)
+        out = capsys.readouterr().out
+        assert "ISTP-GA-005" in out
+
+
+class TestInfoHandling:
+    def _with_info(self) -> ValidationResultGroup:
+        return _file_results(
+            "my.cdf",
+            _rule(
+                "ISTP-GA-004",
+                Severity.ERROR,
+                _leaf(False, Severity.ERROR, "bad logical_file_id", "Logical_file_id"),
+            ),
+            _rule(
+                "ISTP-INFO-001",
+                Severity.INFO,
+                _leaf(False, Severity.INFO, "could add COORDINATE_SYSTEM", "var_a"),
+                _leaf(False, Severity.INFO, "could add COORDINATE_SYSTEM", "var_b"),
+            ),
+        )
+
+    def test_info_not_listed_by_default(self, capsys):
+        report(self._with_info(), output="console")
+        out = capsys.readouterr().out
+        assert "COORDINATE_SYSTEM" not in out
+        assert "ISTP-GA-004" in out
+
+    def test_info_counted_separately_not_as_problems(self, capsys):
+        report(self._with_info(), output="console")
+        out = capsys.readouterr().out
+        assert "1 problem" in out  # only the error
+        assert "2 info" in out  # info surfaced as a count
+
+    def test_show_passed_lists_info(self, capsys):
+        report(self._with_info(), output="console", show_passed=True)
+        out = capsys.readouterr().out
+        assert "COORDINATE_SYSTEM" in out
+
+
+class TestHtmlUnaffectedByDefault:
+    def test_html_default_keeps_passing_results(self, capsys):
+        report(_mixed(), output="html")
+        out = capsys.readouterr().out
+        # HTML stays comprehensive (filter box narrows client-side), passing rule present.
+        assert "version ok" in out

--- a/tests/test_report_ergonomics.py
+++ b/tests/test_report_ergonomics.py
@@ -1,0 +1,199 @@
+"""Tests for result-ergonomics improvements:
+
+- documentation URL propagated from the rule to its result group and rendered (#8)
+- severity label shown only on failing results (#11)
+"""
+
+import io
+
+from rich.console import Console
+
+from astralint.base.file import File
+from astralint.base.validation_result import (
+    Severity,
+    ValidationResult,
+    ValidationResultGroup,
+)
+from astralint.base.yaml_rules.yaml_rule import YamlRule
+from astralint.reports import report
+from astralint.reports.console import console_report
+from astralint.reports.html import generate_html
+
+
+def _render_console(results: ValidationResultGroup) -> str:
+    buf = io.StringIO()
+    console = Console(file=buf, width=200, force_terminal=False, color_system=None)
+    console_report(results, console)
+    return buf.getvalue()
+
+
+class TestUrlPropagation:
+    def test_group_has_url_field_defaulting_to_empty(self):
+        group = ValidationResultGroup(
+            name="g", rule_reference="R-1", severity=Severity.INFO, results=[]
+        )
+        assert group.url == ""
+
+    def test_yaml_rule_check_propagates_url_to_group(self):
+        rule = YamlRule(
+            name="DOIFormat",
+            description="DOI format",
+            url="https://example.org/istp#DOI",
+            reference="ISTP-GA-014",
+            severity=Severity.WARNING,
+            assertions=[],
+        )
+        empty_file = File(
+            filename="x.cdf", extension="cdf", compression="none", attributes={}, variables={}
+        )
+        result = rule.check(empty_file)
+        assert isinstance(result, ValidationResultGroup)
+        assert result.url == "https://example.org/istp#DOI"
+
+    def test_console_renders_url_when_present(self):
+        group = ValidationResultGroup(
+            name="DOIFormat",
+            rule_reference="ISTP-GA-014",
+            url="https://example.org/istp#DOI",
+            severity=Severity.WARNING,
+            results=[
+                ValidationResult(
+                    valid=False,
+                    reference="ISTP-GA-014",
+                    severity=Severity.WARNING,
+                    message="bad DOI",
+                )
+            ],
+        )
+        out = _render_console(group)
+        assert "https://example.org/istp#DOI" in out
+
+    def test_html_renders_url_as_link_when_present(self):
+        group = ValidationResultGroup(
+            name="DOIFormat",
+            rule_reference="ISTP-GA-014",
+            url="https://example.org/istp#DOI",
+            severity=Severity.WARNING,
+            results=[
+                ValidationResult(
+                    valid=False,
+                    reference="ISTP-GA-014",
+                    severity=Severity.WARNING,
+                    message="bad DOI",
+                )
+            ],
+        )
+        html = generate_html(group)
+        assert 'href="https://example.org/istp#DOI"' in html
+
+
+class TestSeverityOnlyOnFailure:
+    def _group(self) -> ValidationResultGroup:
+        return ValidationResultGroup(
+            name="g",
+            rule_reference="R-1",
+            severity=Severity.ERROR,
+            results=[
+                ValidationResult(
+                    valid=True,
+                    reference="R-1",
+                    severity=Severity.ERROR,
+                    message="passed check",
+                ),
+                ValidationResult(
+                    valid=False,
+                    reference="R-2",
+                    severity=Severity.ERROR,
+                    message="failed check",
+                ),
+            ],
+        )
+
+    def test_console_hides_severity_on_passing_result(self):
+        out = _render_console(self._group())
+        # The single ERROR label that survives belongs to the failing result only.
+        assert out.count("(ERROR)") == 1
+
+    def test_html_hides_severity_badge_on_passing_result(self):
+        html = generate_html(self._group())
+        # One severity badge span, for the failing result only.
+        assert html.count('class="severity ERROR"') == 1
+
+
+class TestFailuresOnly:
+    def _group(self) -> ValidationResultGroup:
+        return ValidationResultGroup(
+            name="AstraLint Results",
+            rule_reference="",
+            severity=Severity.INFO,
+            results=[
+                ValidationResult(
+                    valid=True, reference="P-1", severity=Severity.INFO, message="passed"
+                ),
+                ValidationResult(
+                    valid=True, reference="S-1", severity=Severity.SKIPPED, message="skipped"
+                ),
+                ValidationResult(
+                    valid=False, reference="F-1", severity=Severity.ERROR, message="failed"
+                ),
+            ],
+        )
+
+    def test_failures_only_keeps_only_failing_leaves(self):
+        pruned = self._group().failures_only()
+        refs = [r.reference for r in pruned.results if isinstance(r, ValidationResult)]
+        assert refs == ["F-1"]
+
+    def test_failures_only_prunes_emptied_groups(self):
+        outer = ValidationResultGroup(
+            name="outer",
+            rule_reference="",
+            severity=Severity.INFO,
+            results=[
+                ValidationResultGroup(
+                    name="all-pass",
+                    rule_reference="R-1",
+                    severity=Severity.INFO,
+                    results=[
+                        ValidationResult(
+                            valid=True, reference="P-1", severity=Severity.INFO, message="ok"
+                        )
+                    ],
+                )
+            ],
+        )
+        assert outer.failures_only().results == []
+
+    def test_report_failed_only_kwarg(self, capsys):
+        report(self._group(), output="console", failed_only=True)
+        out = capsys.readouterr().out
+        assert "F-1" in out
+        assert "P-1" not in out
+        assert "S-1" not in out
+
+
+class TestHtmlFilterBox:
+    def _group(self) -> ValidationResultGroup:
+        return ValidationResultGroup(
+            name="g",
+            rule_reference="R-1",
+            severity=Severity.ERROR,
+            results=[
+                ValidationResult(valid=True, reference="P-1", severity=Severity.INFO, message="ok"),
+                ValidationResult(
+                    valid=False, reference="F-1", severity=Severity.ERROR, message="bad"
+                ),
+            ],
+        )
+
+    def test_html_has_text_filter_input(self):
+        html = generate_html(self._group())
+        assert 'id="alr-filter"' in html
+
+    def test_html_has_failed_only_toggle(self):
+        html = generate_html(self._group())
+        assert 'id="alr-failed-only"' in html
+
+    def test_html_filter_script_present(self):
+        html = generate_html(self._group())
+        assert "applyFilter" in html

--- a/tests/test_report_ergonomics.py
+++ b/tests/test_report_ergonomics.py
@@ -87,6 +87,34 @@ class TestUrlPropagation:
         assert 'href="https://example.org/istp#DOI"' in html
 
 
+class TestHtmlEscaping:
+    def _group(self, url: str = "", message: str = "msg") -> ValidationResultGroup:
+        return ValidationResultGroup(
+            name="R",
+            rule_reference="R-1",
+            url=url,
+            severity=Severity.ERROR,
+            results=[
+                ValidationResult(
+                    valid=False, reference="R-1", severity=Severity.ERROR, message=message
+                )
+            ],
+        )
+
+    def test_message_with_html_is_escaped(self):
+        html = generate_html(self._group(message="<script>alert(1)</script>"))
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_url_with_quotes_is_escaped(self):
+        html = generate_html(self._group(url='https://x.org/"><img src=x onerror=alert(1)>'))
+        assert '"><img' not in html
+
+    def test_javascript_scheme_url_is_not_linked(self):
+        html = generate_html(self._group(url="javascript:alert(1)"))
+        assert "javascript:alert(1)" not in html
+
+
 class TestSeverityOnlyOnFailure:
     def _group(self) -> ValidationResultGroup:
         return ValidationResultGroup(


### PR DESCRIPTION
## Summary

Makes AstraLint's output behave like a conventional linter and closes the cluster of result-ergonomics issues. Two commits:

1. **More readable, filterable results** — closes #5, #6, #7, #8, #9, #11
2. **Linter-style quiet console output with a verdict line**

## What changed

**Console (the default surface) — now linter-like.** Previously a plain run produced ~650 lines of mostly-passing checks, with no verdict, leaked internal assertion-class names, and INFO suggestions shown as red failures. Now:

- **Quiet by default**: lists only ERROR/WARNING findings, severity-sorted, as a flat `SEVERITY  CODE  target › message` line per file.
- **Always ends with a verdict**: `✗ Found 7 problems (3 errors, 4 warnings), plus 13 info findings` or `✓ All checks passed`.
- **INFO findings** are no longer listed by default nor counted as "problems" — surfaced as a count with a hint.
- `--show-passed` restores the full nested tree; `--output html` for the interactive report.

```
mms1_asp2_srvy_l1b_stat_00000000_v01.cdf
  ERROR   ISTP-GA-004  Logical_file_id › ...should follow logical_source_YYYYMMDD[_vN] format
  WARNING ISTP-VAR-001  Epoch › File must contain an 'Epoch' variable for time tagging
  ...
  13 info finding(s) hidden — use --show-passed or --output html to see them
✗ Found 7 problems (3 errors, 4 warnings), plus 13 info findings
```

**Documentation URL surfaced (#8):** each rule's `url` now propagates to its result group and renders — a `📖 docs` link in HTML group headers and a hyperlink in the console tree. (It lived on `Rule` but never reached the result models, so no reporter could show it.)

**Severity only on failures (#11):** a red "ERROR" no longer sits next to a green check; passing lines stay clean (console + HTML).

**`--failed-only` flag (#9):** `ValidationResultGroup.failures_only()` plus a CLI flag that keeps only failing leaves.

**Interactive HTML filter box (#6/#7):** text search + "show only failed" toggle. Because the Pyodide demo injects report HTML via `innerHTML` (where embedded `<script>` never runs), handlers are also attached in the demo's shared `wireReport()` helper.

**README fix (#5):** corrected the broken `MandatoryGlobalAttributes.yaml` link and documented the new flags/behavior.

## Design note

`OutputConfig.show_passed` becomes tri-state (`bool | None`, default `None`): console treats `None`/`False` as quiet and `True` as the full tree, while HTML/JSON stay comprehensive unless explicitly narrowed — so HTML summary cards keep correct totals.

## Out of scope (deferred to #4, rule-content audit)

A couple of *rule message templates* still read awkwardly (`Attribute FILLVAL of  must be…`, `Expected exactly 1 assertion to pass in 'one_of'`). These are rule content, not reporter bugs.

## Tests

234 passing, lint/types clean, coverage 83.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)