### PR TITLE
demo: auto-load + validate from ?url= deep-link

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -533,6 +533,8 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
                 status.innerHTML = '✓ Ready! Upload a file or load from URL to validate.';
                 document.getElementById('app').style.display = 'block';
 
+                autoRunFromQuery();
+
             } catch (error) {
                 status.className = 'status error';
                 status.innerHTML = '✗ Failed to initialize: ' + error.message;
@@ -608,6 +610,25 @@ validate_file_url(file_url, selected_suite)
             } finally {
                 loadBtn.disabled = false;
             }
+        }
+
+        // Deep-link support: ?url=<file>&suite=<SUITE> prefills and auto-validates.
+        // Lets other tools (e.g. the CDFpp WASM demo) hand a CDF off to AstraLint.
+        function autoRunFromQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const url = params.get('url');
+            if (!url) return;
+
+            const urlInput = document.getElementById('url-input');
+            if (urlInput) urlInput.value = url;
+
+            const suite = params.get('suite');
+            if (suite) {
+                const radio = document.querySelector(`input[name="suite"][value="${suite}"]`);
+                if (radio) radio.checked = true;
+            }
+
+            processFileFromUrl(url);
         }
 
         function applyTheme(theme) {

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -624,8 +624,11 @@ validate_file_url(file_url, selected_suite)
 
             const suite = params.get('suite');
             if (suite) {
-                const radio = document.querySelector(`input[name="suite"][value="${suite}"]`);
-                if (radio) radio.checked = true;
+                // Match by value rather than interpolating into a selector (a crafted
+                // ?suite= with quotes/brackets would make querySelector throw).
+                for (const radio of document.querySelectorAll('input[name="suite"]')) {
+                    if (radio.value === suite) { radio.checked = true; break; }
+                }
             }
 
             processFileFromUrl(url);


### PR DESCRIPTION
## Summary
- The Pyodide demo (`docs/demo/index.html`) now reads `?url=` and `?suite=` query params on load.
- When `url` is present: prefill the URL field, select the suite radio if valid, and auto-run validation once Pyodide + AstraLint finish initializing.
- No behavior change when the params are absent.

## Why
Enables other tools to hand a CDF off to AstraLint via a plain link. Specifically, the CDFpp WebAssembly demo (`wacdfpp`) gains a **Validate (ISTP)** button that opens `https://sciqlop.github.io/AstraLint/?url=<cdf-url>&suite=ISTP` for URL-loaded files — reusing the canonical linter instead of reimplementing ISTP rules in JS.

## Test Plan
- [x] `index.html?url=<served .cdf>&suite=ISTP` auto-prefills the field, selects ISTP, and renders a real conformance report (verified locally via Playwright: 36 PASSED / 60 FAILED / 2 WARNINGS on a sample CDF, zero console errors).
- [x] Opening `index.html` with no params behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)