### PR TITLE
demo: accept a CDF via postMessage from an opener

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -535,6 +535,10 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
 
                 autoRunFromQuery();
 
+                // Tell an opener (e.g. the CDFpp WASM demo) we're ready to receive
+                // a file via postMessage. See the 'message' listener below.
+                if (window.opener) window.opener.postMessage({ type: 'astralint-ready' }, '*');
+
             } catch (error) {
                 status.className = 'status error';
                 status.innerHTML = '✗ Failed to initialize: ' + error.message;
@@ -542,18 +546,17 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             }
         }
 
-        async function processFile(file) {
+        // Validate raw bytes. suiteName defaults to the currently-checked radio.
+        // Shared by local uploads (processFile) and the postMessage handoff.
+        async function validateBytes(uint8Array, name, suiteName) {
             const results = document.getElementById('results');
             results.innerHTML = '<div class="status loading"><div class="spinner"></div><span>Validating...</span></div>';
 
             try {
-                const arrayBuffer = await file.arrayBuffer();
-                const uint8Array = new Uint8Array(arrayBuffer);
-
                 // Pass file to Python
                 pyodide.globals.set('file_bytes', uint8Array);
-                pyodide.globals.set('file_name', file.name);
-                pyodide.globals.set('selected_suite', document.querySelector('input[name="suite"]:checked').value);
+                pyodide.globals.set('file_name', name);
+                pyodide.globals.set('selected_suite', suiteName || document.querySelector('input[name="suite"]:checked').value);
 
                 const html = await pyodide.runPythonAsync(`
 validate_file_bytes(file_bytes.to_py(), file_name, selected_suite)
@@ -572,6 +575,11 @@ validate_file_bytes(file_bytes.to_py(), file_name, selected_suite)
                 results.innerHTML = '<div class="status error">✗ Error: ' + error.message + '</div>';
                 console.error(error);
             }
+        }
+
+        async function processFile(file) {
+            const arrayBuffer = await file.arrayBuffer();
+            await validateBytes(new Uint8Array(arrayBuffer), file.name);
         }
 
         async function processFileFromUrl(url) {
@@ -697,6 +705,21 @@ validate_file_url(file_url, selected_suite)
                 if (e.key === 'Enter' && pyodide) {
                     processFileFromUrl(urlInput.value);
                 }
+            });
+
+            // Accept a CDF handed off via postMessage (e.g. from the CDFpp WASM demo
+            // for local files that can't be passed by ?url=). We replied 'astralint-ready'
+            // to our opener after init, so by the time a file arrives pyodide is ready.
+            window.addEventListener('message', (e) => {
+                const d = e.data;
+                if (!d || d.type !== 'astralint-file' || !d.bytes || !pyodide) return;
+                if (d.suite) {
+                    for (const radio of document.querySelectorAll('input[name="suite"]')) {
+                        if (radio.value === d.suite) { radio.checked = true; break; }
+                    }
+                }
+                const bytes = d.bytes instanceof Uint8Array ? d.bytes : new Uint8Array(d.bytes);
+                validateBytes(bytes, d.name || 'file.cdf', d.suite);
             });
 
             initPyodide();

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -464,6 +464,13 @@
     <script>
         let pyodide = null;
 
+        // Origin of the window that opened us (from the referrer), for targeting the
+        // postMessage handshake; '*' when the referrer is unavailable.
+        function openerOrigin() {
+            try { return document.referrer ? new URL(document.referrer).origin : '*'; }
+            catch { return '*'; }
+        }
+
         async function initPyodide() {
             const status = document.getElementById('loading-status');
 
@@ -536,8 +543,9 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
                 autoRunFromQuery();
 
                 // Tell an opener (e.g. the CDFpp WASM demo) we're ready to receive
-                // a file via postMessage. See the 'message' listener below.
-                if (window.opener) window.opener.postMessage({ type: 'astralint-ready' }, '*');
+                // a file via postMessage. Target the opener's origin (from the
+                // referrer) so only it sees the handshake; '*' only as a fallback.
+                if (window.opener) window.opener.postMessage({ type: 'astralint-ready' }, openerOrigin());
 
             } catch (error) {
                 status.className = 'status error';
@@ -710,16 +718,23 @@ validate_file_url(file_url, selected_suite)
             // Accept a CDF handed off via postMessage (e.g. from the CDFpp WASM demo
             // for local files that can't be passed by ?url=). We replied 'astralint-ready'
             // to our opener after init, so by the time a file arrives pyodide is ready.
+            // Only the opener may post here, to keep arbitrary pages out of the pipeline.
             window.addEventListener('message', (e) => {
+                if (e.source !== window.opener) return;
                 const d = e.data;
                 if (!d || d.type !== 'astralint-file' || !d.bytes || !pyodide) return;
+
+                // Select the suite radio only when the requested suite is recognized;
+                // an unknown suite falls back to the currently-checked one.
+                let suiteName;
                 if (d.suite) {
                     for (const radio of document.querySelectorAll('input[name="suite"]')) {
-                        if (radio.value === d.suite) { radio.checked = true; break; }
+                        if (radio.value === d.suite) { radio.checked = true; suiteName = d.suite; break; }
                     }
                 }
+
                 const bytes = d.bytes instanceof Uint8Array ? d.bytes : new Uint8Array(d.bytes);
-                validateBytes(bytes, d.name || 'file.cdf', d.suite);
+                validateBytes(bytes, d.name || 'file.cdf', suiteName);
             });
 
             initPyodide();


### PR DESCRIPTION
## Summary
- Extract `validateBytes(uint8Array, name, suiteName)` from `processFile` (shared by local uploads and the new handoff; `processFile` now just reads the file and delegates).
- After init, post `{ type: "astralint-ready" }` to `window.opener` (if any).
- Add a `message` listener that validates a `{ type: "astralint-file", name, suite, bytes }` payload — selecting the suite radio when provided, then validating the bytes. Ignored until Pyodide is ready (the ready handshake guarantees ordering).

## Why
Stage 2 of the CDFpp WASM demo (`wacdfpp`) integration. Stage 1 (merged, #15) deep-links URL-sourced CDFs via `?url=`. This lets the demo validate **local / drag-drop** files too: it opens this page, waits for `astralint-ready`, and transfers the file bytes via `postMessage` (Transferable ArrayBuffer).

## Test Plan
- [x] End-to-end (Playwright): the CDFpp demo loads a local CDF, clicks Validate, this page opens, completes init, receives the bytes, and renders a real ISTP report (36 PASSED / 60 FAILED / 2 WARNINGS on a sample CDF).
- [x] Local file upload and `?url=` paths still work (both now go through `validateBytes`).
- [x] Opening this page directly (no opener) is unaffected.

## Note
Bytes-loaded validation shows `file ''` in the report header (the codec loads from bytes with no name) — pre-existing behavior shared with the local-upload path; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)