### PR TITLE
fix(istp): correct rule↔guideline mapping, per-variable conditionals, name-agnostic epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ assertions:
 ## Available Conformance Suites (WIP/Demo)
 
 - **ISTP** - [ISTP Metadata Guidelines](https://istp-metadata.readthedocs.io/)
+- **CDAWeb** - [CDAWeb](https://cdaweb.gsfc.nasa.gov/) ingestion profile: inherits ISTP and promotes the CDAWeb-required attributes (`Instrument_type`, `Mission_group`) to errors, plus CDAWeb-specific entry limits
 - **PDS4** - [Planetary Data System v4](https://pds.nasa.gov/datastandards/documents/)
 - **SOLARNET** - [SOLARNET Metadata Recommendations](https://solarnet.readthedocs.io/en/stable/index.html)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # AstraLint
 
 AstraLint is a Python linter for Space Physics data files, validating conformance to standards such
-as [ISTP](https://spdf.gsfc.nasa.gov/istp_guide/) and [PDS4](https://pds.nasa.gov/datastandards/documents/).
+as [ISTP](https://istp-metadata.readthedocs.io/) and [PDS4](https://pds.nasa.gov/datastandards/documents/).
 
 <p align="center">
   <a href="https://sciqlop.github.io/AstraLint/"><strong>🚀 Try it online — no installation required!</strong></a>
@@ -281,7 +281,7 @@ assertions:
 
 ## Available Conformance Suites (WIP/Demo)
 
-- **ISTP** - [ISTP Metadata Guidelines](https://spdf.gsfc.nasa.gov/istp_guide/)
+- **ISTP** - [ISTP Metadata Guidelines](https://istp-metadata.readthedocs.io/)
 - **PDS4** - [Planetary Data System v4](https://pds.nasa.gov/datastandards/documents/)
 - **SOLARNET** - [SOLARNET Metadata Recommendations](https://solarnet.readthedocs.io/en/stable/index.html)
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ assertions:
 | **String** | `matches` |
 | **Collection** | `contains_keys`, `in`, `not_in`, `length`, `not_empty`, `requires`, `array_shape` |
 | **Relationship** | `reference_variable`, `compare_to` |
-| **Combinators** | `all_of`, `any_of`, `none_of`, `not`, `one_of`, `at_least`, `at_most`, `exactly` |
+| **Combinators** | `all_of`, `any_of`, `any_match`, `none_of`, `not`, `one_of`, `at_least`, `at_most`, `exactly` |
 | **Conditional** | `if_then`, `if_then_else` |
 
 📖 **[Full Assertions Reference →](docs/assertions.md)**

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -26,6 +26,7 @@ Assertions are the building blocks of validation rules. Each assertion checks a 
 | `none_of` | Combinator | None must pass (NOR) |
 | `not` | Combinator | Nested assertion must fail (NOT) |
 | `one_of` | Combinator | Exactly one must pass (XOR) |
+| `any_match` | Combinator | At least one match of a wildcard assertion passes (exists) |
 | `if_then` | Conditional | If condition passes, then assertion must pass |
 | `if_then_else` | Conditional | If-then with else branch |
 | `at_least` | Counting | At least N assertions must pass |
@@ -330,6 +331,24 @@ At least one nested assertion must pass (logical OR).
     - path: "DEPEND_TIME"
       check: exists
       message: ""
+```
+
+### `any_match`
+
+Wraps a single assertion and passes if **at least one** of its matches passes
+(existential quantifier). A wildcard-path assertion (e.g. `variables/.*/data_type`)
+normally only "passes" when *every* matched value satisfies it; `any_match` flips
+that to "passes when at least one match satisfies it". This is the way to express
+"the dataset contains at least one variable of kind X" without assuming a name.
+
+```yaml
+# The dataset must contain at least one CDF time (epoch) variable, under any name.
+- check: any_match
+  message: "{% if valid %}dataset contains a CDF time variable{% else %}dataset must contain a CDF time variable{% endif %}"
+  assertion:
+    path: "variables/.*/data_type"
+    check: in
+    values: [CDFEPOCH, CDFEPOCH16, TT2000]
 ```
 
 ### `none_of`

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -419,6 +419,29 @@ This implements logical implication: `condition → assertion`
 - Skipped assertions are treated as passing in parent combinators like `all_of`
 - This allows conditional rules that don't fail when the condition doesn't apply
 
+**Per-variable conditionals (path captures):**
+
+When the `if` path contains a named capture like `{var}`, the condition and the
+`then`/`else` branches are evaluated **once per matched binding**, with the
+capture interpolated into every path (and message) of the branch. This correlates
+the condition and the requirement on the *same* variable — without it, a wildcard
+condition such as `variables/.*/.../VAR_TYPE == "data"` would only be satisfied
+when *every* variable shares that type, silently skipping mixed-type files.
+
+```yaml
+# For each variable whose VAR_TYPE is "data", require DEPEND_0 on that variable.
+- check: if_then
+  if:
+    path: "variables/{var}/attributes/VAR_TYPE/values/0"
+    check: comparison
+    operator: "="
+    value: "data"
+  then:
+    path: "variables/{var}/attributes"
+    check: contains_keys
+    keys: [DEPEND_0]
+```
+
 ### `if_then_else`
 
 If the condition passes, run the `then` branch; otherwise, run the `else` branch. Unlike `if_then`, this always runs one of the two branches (never skipped).

--- a/src/astralint/base/conformance_suite.py
+++ b/src/astralint/base/conformance_suite.py
@@ -158,11 +158,25 @@ class _ConformanceSuiteProtocolCtor:
         self.inherit_from = inherit_from or []
         self.severity_overrides = severity_overrides or {}
 
+    def _parse_overrides(self) -> dict[str, Severity]:
+        parsed: dict[str, Severity] = {}
+        for reference, value in self.severity_overrides.items():
+            try:
+                parsed[reference] = Severity(value)
+            except ValueError as error:
+                allowed = ", ".join(level.value for level in Severity)
+                raise ValueError(
+                    f"Invalid severity '{value}' for rule '{reference}' in "
+                    f"severity_overrides of suite '{self.name}'; expected one of: {allowed}"
+                ) from error
+        return parsed
+
     def __call__(self) -> ConformanceSuite:
         inherited_rules = parents_rules(self.inherit_from)
         if self.severity_overrides:
-            overrides = {ref: Severity(value) for ref, value in self.severity_overrides.items()}
-            inherited_rules = list(apply_severity_overrides(inherited_rules, overrides))
+            inherited_rules = list(
+                apply_severity_overrides(inherited_rules, self._parse_overrides())
+            )
 
         load_rules_from_dir(self.rules_lookup_dir)
         own_rules = get_rules_for_suite(self.name)

--- a/src/astralint/base/conformance_suite.py
+++ b/src/astralint/base/conformance_suite.py
@@ -118,6 +118,10 @@ class ConformanceSuiteYaml(BaseModel):
     inherit_from: list[str] = Field(
         default_factory=list, description="List of suite names to inherit rules from."
     )
+    severity_overrides: dict[str, str] = Field(
+        default_factory=dict,
+        description="Override the severity of inherited rules, keyed by rule reference.",
+    )
 
 
 def load_suite_from_yaml(path: str) -> ConformanceSuiteYaml:
@@ -141,15 +145,24 @@ def parents_rules(parents: list[str]) -> list[Rule]:
 
 class _ConformanceSuiteProtocolCtor:
     def __init__(
-        self, name: str, rules_lookup_dir: str, inherit_from: list[str] | None = None, **kwargs
+        self,
+        name: str,
+        rules_lookup_dir: str,
+        inherit_from: list[str] | None = None,
+        severity_overrides: dict[str, str] | None = None,
+        **kwargs,
     ):
         self.kwargs = kwargs
         self.name = name
         self.rules_lookup_dir = rules_lookup_dir
         self.inherit_from = inherit_from or []
+        self.severity_overrides = severity_overrides or {}
 
     def __call__(self) -> ConformanceSuite:
         inherited_rules = parents_rules(self.inherit_from)
+        if self.severity_overrides:
+            overrides = {ref: Severity(value) for ref, value in self.severity_overrides.items()}
+            inherited_rules = list(apply_severity_overrides(inherited_rules, overrides))
 
         load_rules_from_dir(self.rules_lookup_dir)
         own_rules = get_rules_for_suite(self.name)
@@ -167,6 +180,7 @@ def register_suite(
     rules_lookup_dir: str,
     alternative_names: list[str] | None = None,
     inherit_from: list[str] | None = None,
+    severity_overrides: dict[str, str] | None = None,
 ) -> _ConformanceSuiteProtocolCtor:
     ctor = _ConformanceSuiteProtocolCtor(
         description=description,
@@ -174,6 +188,7 @@ def register_suite(
         name=name,
         rules_lookup_dir=rules_lookup_dir,
         inherit_from=inherit_from,
+        severity_overrides=severity_overrides,
     )
     SUITES[name] = ctor
     if alternative_names:

--- a/src/astralint/base/loader.py
+++ b/src/astralint/base/loader.py
@@ -68,4 +68,5 @@ def load_suite_from_dir(path: str | Path, suite_name: str):
             rules_lookup_dir=str(suite_dir / "rules"),
             name=suite.name,
             inherit_from=suite.inherit_from,
+            severity_overrides=suite.severity_overrides,
         )

--- a/src/astralint/base/yaml_rules/assertions/combinations.py
+++ b/src/astralint/base/yaml_rules/assertions/combinations.py
@@ -5,7 +5,89 @@ from pydantic import ConfigDict, Field, model_validator
 from ... import ValidationResultGroup
 from ...file import File
 from ...validation_result import Severity, ValidationResult
-from .base import BaseAssertionGroup, BaseEvaluable, get_assertion_union
+from .base import (
+    BaseAssertionGroup,
+    BaseEvaluable,
+    get_assertion_union,
+    interpolate_captures,
+    parse_captures,
+    render_message,
+    resolve_path_with_captures,
+)
+
+
+def _path_capture_names(assertion: Any) -> list[str]:
+    """Names of {capture} placeholders in an assertion's own ``path`` (if any)."""
+    path = getattr(assertion, "path", None)
+    if not isinstance(path, str):
+        return []
+    _, names = parse_captures(path)
+    return names
+
+
+def _concretize(assertion: Any, captures: dict[str, str]) -> Any:
+    """Return a copy of an assertion tree with {capture} placeholders interpolated.
+
+    This is what makes ``if_then`` correlate a condition and its requirement on the
+    *same* variable: the capture bound by the condition's path (e.g. ``{var}``) is
+    substituted into every path of the ``then`` branch.
+    """
+    if not captures:
+        return assertion
+    update: dict[str, Any] = {}
+    for field in ("path", "other_path", "message"):
+        value = getattr(assertion, field, None)
+        if isinstance(value, str):
+            update[field] = interpolate_captures(value, captures)
+    subs = getattr(assertion, "assertions", None)
+    if isinstance(subs, list):
+        update["assertions"] = [_concretize(a, captures) for a in subs]
+    for field in ("assertion", "if_", "then", "else_"):
+        child = getattr(assertion, field, None)
+        if isinstance(child, BaseEvaluable):
+            update[field] = _concretize(child, captures)
+    if not update:
+        return assertion
+    return assertion.model_copy(update=update)
+
+
+def _distinct_bindings(file: File, if_path: str) -> list[dict[str, str]]:
+    bindings: list[dict[str, str]] = []
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    for _path, _value, captures in resolve_path_with_captures(file, if_path):
+        key = tuple(sorted(captures.items()))
+        if key not in seen:
+            seen.add(key)
+            bindings.append(captures)
+    return bindings
+
+
+def _evaluate_per_capture(
+    if_: Any,
+    then: Any,
+    else_: Any | None,
+    file: File,
+    severity: Severity,
+    name: str,
+) -> ValidationResult | ValidationResultGroup:
+    """Evaluate a conditional once per distinct binding of the condition's path
+    captures (e.g. ``{var}``), correlating the requirement with the matched variable."""
+    results: list[Any] = []
+    for captures in _distinct_bindings(file, if_.path):
+        condition = _concretize(if_, captures).evaluate(file, severity)
+        if condition.valid:
+            results.append(_concretize(then, captures).evaluate(file, severity))
+        elif else_ is not None:
+            results.append(_concretize(else_, captures).evaluate(file, severity))
+    if not results:
+        return ValidationResult(
+            valid=True,
+            reference="",
+            severity=Severity.SKIPPED,
+            message="Condition not met for any binding, assertion skipped.",
+            target="",
+        )
+    return ValidationResultGroup(name=name, rule_reference="", results=results, severity=severity)
 
 
 class AllOf(BaseAssertionGroup):
@@ -120,6 +202,51 @@ class Not(BaseEvaluable):
         )
 
 
+class AnyMatch(BaseEvaluable):
+    """Existential quantifier over a wrapped assertion's results.
+
+    A wildcard-path assertion (e.g. ``variables/.*/data_type``) normally only
+    "passes" when *every* matched value satisfies it. ``any_match`` flips that to
+    "passes when *at least one* match satisfies it" — useful for requirements like
+    "the dataset contains at least one CDF time (epoch) variable", which must not
+    assume a particular variable name."""
+
+    model_config = ConfigDict(frozen=True)
+    check: Literal["any_match"] = "any_match"  # type: ignore[assignment]
+    assertion: Any
+    message: str = Field(default="")
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_assertion(cls, data: dict) -> dict:
+        assertion_union = get_assertion_union()
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(assertion_union)
+        if "assertion" in data:
+            data["assertion"] = adapter.validate_python(data["assertion"])
+        return data
+
+    def evaluate(self, file: File, severity: Severity) -> ValidationResult:
+        result = self.assertion.evaluate(file, severity)
+        if isinstance(result, ValidationResultGroup):
+            passed = result.count_by_severity()["passed"] > 0
+        else:
+            passed = result.valid and result.severity != Severity.SKIPPED
+        default = (
+            "at least one match satisfied the condition"
+            if passed
+            else "no match satisfied the condition"
+        )
+        return ValidationResult(
+            valid=passed,
+            reference="",
+            severity=severity,
+            message=render_message(self.message, {"valid": passed}) if self.message else default,
+            target="",
+        )
+
+
 class IfThen(BaseEvaluable):
     """Conditional assertion: if condition passes, then assertion must pass.
     If condition fails, the assertion is skipped (vacuously true)."""
@@ -144,6 +271,8 @@ class IfThen(BaseEvaluable):
         return data
 
     def evaluate(self, file: File, severity: Severity) -> ValidationResultGroup | ValidationResult:
+        if _path_capture_names(self.if_):
+            return _evaluate_per_capture(self.if_, self.then, None, file, severity, "IfThen")
         condition_result = self.if_.evaluate(file, severity)
         if not condition_result.valid:
             return ValidationResult(
@@ -187,6 +316,10 @@ class IfThenElse(BaseEvaluable):
         return data
 
     def evaluate(self, file: File, severity: Severity) -> ValidationResult | ValidationResultGroup:
+        if _path_capture_names(self.if_):
+            return _evaluate_per_capture(
+                self.if_, self.then, self.else_, file, severity, "IfThenElse"
+            )
         condition_result = self.if_.evaluate(file, severity)
         if condition_result.valid:
             then_result = self.then.evaluate(file, severity)

--- a/src/astralint/base/yaml_rules/assertions/combinations.py
+++ b/src/astralint/base/yaml_rules/assertions/combinations.py
@@ -228,7 +228,14 @@ class AnyMatch(BaseEvaluable):
         return data
 
     def evaluate(self, file: File, severity: Severity) -> ValidationResult:
-        result = self.assertion.evaluate(file, severity)
+        # For an existential quantifier, "no matches at all" must be a failure.
+        # Neutralize any lenient `error_if_no_match: false` on the wrapped (path)
+        # assertion so that an empty match set yields a failing leaf rather than a
+        # vacuously-valid one.
+        assertion = self.assertion
+        if getattr(assertion, "error_if_no_match", None) is False:
+            assertion = assertion.model_copy(update={"error_if_no_match": True})
+        result = assertion.evaluate(file, severity)
         if isinstance(result, ValidationResultGroup):
             passed = result.count_by_severity()["passed"] > 0
         else:

--- a/src/astralint/base/yaml_rules/yaml_rule.py
+++ b/src/astralint/base/yaml_rules/yaml_rule.py
@@ -65,4 +65,12 @@ def register_yaml_rule(yaml_path: Path):
         data = yaml.safe_load(f)
     suite = data["suite"]
     rule = YamlRule(**data)
-    RULES.setdefault(suite, []).append(rule)
+    # Idempotent: a suite may be (re)loaded several times — directly and as a
+    # parent of an inheriting suite — so replace any rule of the same name
+    # instead of appending a duplicate.
+    rules = RULES.setdefault(suite, [])
+    for index, existing in enumerate(rules):
+        if existing.name == rule.name:
+            rules[index] = rule
+            return
+    rules.append(rule)

--- a/src/astralint/suites/CDAWeb/rules/CDAWebEntryLimits.yaml
+++ b/src/astralint/suites/CDAWeb/rules/CDAWebEntryLimits.yaml
@@ -1,0 +1,28 @@
+name: CDAWebEntryLimits
+description: "CDAWeb allows at most five entries for multi-valued instrument/link attributes"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
+reference: "CDAWEB-GA-001"
+severity: ERROR
+suite: CDAWeb
+
+assertions:
+  - path: "attributes/Instrument_type/values"
+    check: length
+    max: 5
+    error_if_no_match: false
+    message: "{% if valid %}Instrument_type entry count is within the CDAWeb limit{% else %}Instrument_type has {{ length }} entries; CDAWeb allows at most 5{% endif %}"
+  - path: "attributes/HTTP_LINK/values"
+    check: length
+    max: 5
+    error_if_no_match: false
+    message: "{% if valid %}HTTP_LINK entry count is within the CDAWeb limit{% else %}HTTP_LINK has {{ length }} entries; CDAWeb allows at most 5{% endif %}"
+  - path: "attributes/LINK_TEXT/values"
+    check: length
+    max: 5
+    error_if_no_match: false
+    message: "{% if valid %}LINK_TEXT entry count is within the CDAWeb limit{% else %}LINK_TEXT has {{ length }} entries; CDAWeb allows at most 5{% endif %}"
+  - path: "attributes/LINK_TITLE/values"
+    check: length
+    max: 5
+    error_if_no_match: false
+    message: "{% if valid %}LINK_TITLE entry count is within the CDAWeb limit{% else %}LINK_TITLE has {{ length }} entries; CDAWeb allows at most 5{% endif %}"

--- a/src/astralint/suites/CDAWeb/suite.yaml
+++ b/src/astralint/suites/CDAWeb/suite.yaml
@@ -1,0 +1,11 @@
+name: CDAWeb
+description: "CDAWeb ingestion profile: ISTP plus the attributes CDAWeb additionally requires"
+url: "https://cdaweb.gsfc.nasa.gov/"
+rules_lookup_dir: "rules"
+inherit_from:
+  - ISTP
+severity_overrides:
+  # Instrument_type and Mission_group are only *recommended* by ISTP, but are
+  # REQUIRED for ingestion into CDAWeb, so the inherited rule is promoted to an
+  # error in this profile.
+  ISTP-GA-016: ERROR

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/CDAWebRequiredGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/CDAWebRequiredGlobalAttributes.yaml
@@ -1,0 +1,16 @@
+name: CDAWebRequiredGlobalAttributes
+description: "Global attributes that are ISTP-recommended but required by CDAWeb"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
+reference: "ISTP-GA-016"
+# Recommended by ISTP, required for ingestion into CDAWeb -> warning, not error.
+severity: WARNING
+suite: ISTP
+
+assertions:
+  - path: "attributes"
+    check: contains_keys
+    error_if_no_match: false
+    keys:
+      - Instrument_type
+      - Mission_group
+    message: "{% if valid %}all CDAWeb-required global attributes present{% else %}missing CDAWeb-required global attribute(s) (recommended by ISTP): {{ missing_keys | join(', ') }}{% endif %}"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
@@ -1,6 +1,6 @@
 name: DOIFormat
 description: "DOI must use the standard https://doi.org/ format"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#DOI"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#doi"
 reference: "ISTP-GA-014"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
@@ -1,16 +1,17 @@
 name: DataTypeFormat
 description: "Data_type must follow ISTP convention: ABBREV>Full_description"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Data_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#data_type"
 reference: "ISTP-GA-006"
 severity: ERROR
 suite: ISTP
 
 assertions:
-  # Data_type format: ABBREV>Full_description (e.g., "K0>Key Parameters")
+  # Data_type format: ABBREV>Full_description. The short name may contain
+  # hyphens and lowercase letters (e.g. "L2-Summary", "l2-gms-62ms").
   - path: "attributes/Data_type/values/[0-9]*"
     check: matches
-    pattern: "^[A-Z0-9_]+>.+$"
-    message: "Data_type must follow format: ABBREV>Full_description (e.g., 'K0>Key Parameters')"
+    pattern: "^[A-Za-z0-9_-]+>.+$"
+    message: "Data_type must follow format: ABBREV>Full_description (e.g., 'L2-Summary>level 2 summary')"
 
   - path: "attributes/Data_type/values/[0-9]*"
     check: not_empty

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
@@ -1,6 +1,6 @@
 name: DataVersionFormat
 description: "Data_version must be a valid version string"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Data_version"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#data_version"
 reference: "ISTP-GA-005"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
@@ -1,6 +1,6 @@
 name: DescriptorFormat
 description: "Descriptor must follow ISTP convention: ABBREV>Full_description"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Descriptor"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#descriptor"
 reference: "ISTP-GA-008"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
@@ -1,6 +1,6 @@
 name: DisciplineValues
 description: "Discipline should use standard ISTP values"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Discipline"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#discipline"
 reference: "ISTP-GA-009"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
@@ -1,6 +1,6 @@
 name: GenerationDateFormat
 description: "Generation_date must use yyyymmdd format"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Generation_date"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#generation_date"
 reference: "ISTP-GA-015"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
@@ -1,6 +1,6 @@
 name: InstrumentTypeValues
 description: "Instrument_type should use standard ISTP values"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Instrument_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
 reference: "ISTP-GA-010"
 severity: WARNING
 suite: ISTP
@@ -11,6 +11,7 @@ assertions:
     error_if_no_match: false
     values:
       - "Activity Indices"
+      - "Dust and Debris"
       - "Electric Fields (space)"
       - "Engineering"
       - "Ephemeris/Attitude/Ancillary"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
@@ -1,6 +1,6 @@
 name: LinkCountConsistency
 description: "HTTP_LINK, LINK_TEXT, and LINK_TITLE must have the same number of entries"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#LINK_TEXT"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#link_text-link_title-http_link"
 reference: "ISTP-GA-013"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
@@ -1,15 +1,16 @@
 name: LogicalFileIdFormat
 description: "Logical_file_id must match the filename and include date and version"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Logical_file_id"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#logical_file_id"
 reference: "ISTP-GA-004"
 severity: ERROR
 suite: ISTP
 
 assertions:
-  # Must contain logical_source + date + version pattern
+  # logical_source + date + version. The short names embedded in logical_source
+  # may contain hyphens (e.g. "psp_isois_l2-summary_20180928_v07").
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: matches
-    pattern: "^[a-z0-9_]+_\\d{8}(_v\\d+)?$"
+    pattern: "^[a-z0-9_-]+_\\d{8}(_v\\d+)?$"
     message: "Logical_file_id should follow: logical_source_YYYYMMDD[_vN] format"
 
   - path: "attributes/Logical_file_id/values/[0-9]*"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
@@ -1,6 +1,6 @@
 name: LogicalSourceFormat
 description: "Logical_source must follow ISTP naming convention: source_descriptor_datatype"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Logical_source"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#logical_source"
 reference: "ISTP-GA-003"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/MandatoryGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/MandatoryGlobalAttributes.yaml
@@ -1,23 +1,23 @@
 name: MandatoryGlobalAttributes
 description: "All mandatory global attributes must be present (ISTP/SPDF required)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html"
 reference: "ISTP-GA-001"
 severity: ERROR
 suite: ISTP
 
 assertions:
-  # Required global attributes per ISTP guidelines Section 3
+  # Attributes marked "Required" in the ISTP global-attribute table (Section 3).
+  # Note: Instrument_type and Mission_group are "Recommended, required by CDAWeb"
+  # rather than ISTP-required, so they live in CDAWebRequiredGlobalAttributes.
   - path: "attributes"
     check: contains_keys
     keys:
       - Data_type
       - Data_version
       - Descriptor
-      - Instrument_type
       - Logical_file_id
       - Logical_source
       - Logical_source_description
-      - Mission_group
       - PI_affiliation
       - PI_name
       - Source_name

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
@@ -1,18 +1,22 @@
 name: ProjectFormat
 description: "Project must follow ISTP convention"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Project"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#project"
 reference: "ISTP-GA-012"
-severity: ERROR
+# Project is a *Recommended* attribute, so a malformed value is a warning, not an error.
+severity: WARNING
 suite: ISTP
 
 assertions:
-  # Project can be multi-valued, format: ABBREV>Full_Name
+  # Project can be multi-valued, format: ABBREV>Full_Name. The short name may
+  # contain spaces and lowercase letters (e.g. "STSP Cluster", "CDAWxx").
   - path: "attributes/Project/values/[0-9]*"
     check: matches
-    pattern: "^[A-Z0-9_-]+>.+$"
+    error_if_no_match: false
+    pattern: "^[A-Za-z0-9_ -]+>.+$"
     message: "Project must follow format: ABBREV>Full_Name (e.g., 'ISTP>International Solar-Terrestrial Physics')"
 
   - path: "attributes/Project/values/[0-9]*"
     check: not_empty
+    error_if_no_match: false
     message: "Project cannot be empty"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/RecommendedGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/RecommendedGlobalAttributes.yaml
@@ -1,6 +1,6 @@
 name: RecommendedGlobalAttributes
 description: "Recommended global attributes should be present for better data discoverability"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html"
 reference: "ISTP-GA-002"
 severity: WARNING
 suite: ISTP
@@ -13,6 +13,7 @@ assertions:
       - Acknowledgement
       - Discipline
       - DOI
+      - File_naming_convention
       - Generated_by
       - Generation_date
       - HTTP_LINK

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
@@ -1,6 +1,6 @@
 name: SourceNameFormat
 description: "Source_name must follow ISTP convention: ABBREV>Full_Name"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Source_name"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#source_name"
 reference: "ISTP-GA-007"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
@@ -1,17 +1,14 @@
 name: TextNotEmpty
 description: "TEXT attribute must contain meaningful description of the data"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#TEXT"
+url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#text"
 reference: "ISTP-GA-011"
 severity: ERROR
 suite: ISTP
 
 assertions:
+  # TEXT is Required and must describe the data. The ISTP Guidelines do not
+  # prescribe a minimum length, so only emptiness is enforced as an error.
   - path: "attributes/TEXT/values/[0-9]*"
     check: not_empty
     message: "TEXT global attribute cannot be empty - must describe the data"
-
-  - path: "attributes/TEXT/values/[0-9]*"
-    check: length
-    min: 20
-    message: "TEXT should contain a meaningful description (at least 20 characters)"
 

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescLength.yaml
@@ -1,6 +1,6 @@
 name: CatdescLength
 description: "CATDESC should be descriptive but concise (80 characters max per ISTP)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#CATDESC"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#catdesc"
 reference: "ISTP-VA-006"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescMaxLength.yaml
@@ -1,6 +1,6 @@
 name: CatdescMaxLength
 description: "CATDESC must not exceed 120 characters (hard limit)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#CATDESC"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#catdesc"
 reference: "ISTP-VA-020"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: DataVariableAttributes
 description: "Data variables (VAR_TYPE=data) must have additional required attributes"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#data-variables"
 reference: "ISTP-VA-002"
 severity: ERROR
 suite: ISTP
@@ -8,14 +8,14 @@ suite: ISTP
 assertions:
   - check: if_then
     if:
-      path: "variables/.*/attributes/VAR_TYPE/values/[0-9]*"
+      path: "variables/{var}/attributes/VAR_TYPE/values/0"
       check: comparison
       operator: "="
       value: "data"
     then:
       check: all_of
       assertions:
-        - path: "variables/.*/attributes"
+        - path: "variables/{var}/attributes"
           check: contains_keys
           keys:
             - DEPEND_0
@@ -26,23 +26,18 @@ assertions:
         - check: any_of
           message: "Data variable must have LABLAXIS or LABL_PTR_1"
           assertions:
-            - path: "variables/.*/attributes/LABLAXIS"
+            - path: "variables/{var}/attributes/LABLAXIS"
               check: exists
-              error_if_no_match: false
               message: ""
-            - path: "variables/.*/attributes/LABL_PTR_1"
+            - path: "variables/{var}/attributes/LABL_PTR_1"
               check: exists
-              error_if_no_match: false
               message: ""
         - check: any_of
           message: "Data variable must have UNITS or UNIT_PTR"
           assertions:
-            - path: "variables/.*/attributes/UNITS"
+            - path: "variables/{var}/attributes/UNITS"
               check: exists
-              error_if_no_match: false
               message: ""
-            - path: "variables/.*/attributes/UNIT_PTR"
+            - path: "variables/{var}/attributes/UNIT_PTR"
               check: exists
-              error_if_no_match: false
               message: ""
-

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DeltaReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DeltaReferences.yaml
@@ -1,6 +1,6 @@
 name: DeltaReferences
 description: "DELTA_PLUS_VAR and DELTA_MINUS_VAR must reference existing variables"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DELTA_PLUS_VAR"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#delta_plus_var-delta_minus_var"
 reference: "ISTP-VA-014"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DependReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DependReferences.yaml
@@ -1,6 +1,6 @@
 name: DependReferences
 description: "DEPEND_0, DEPEND_1, DEPEND_2, DEPEND_3 must reference existing variables"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DEPEND_0"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#depend_0"
 reference: "ISTP-VA-011"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
@@ -1,6 +1,6 @@
 name: DisplayTypeValues
 description: "DISPLAY_TYPE should use standard ISTP values"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DISPLAY_TYPE"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#display_type"
 reference: "ISTP-VA-005"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamLength.yaml
@@ -1,6 +1,6 @@
 name: FieldnamLength
 description: "FIELDNAM should be concise for plot labels (30 characters max)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FIELDNAM"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fieldnam"
 reference: "ISTP-VA-007"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamMaxLength.yaml
@@ -1,6 +1,6 @@
 name: FieldnamMaxLength
 description: "FIELDNAM must not exceed 50 characters (hard limit)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FIELDNAM"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fieldnam"
 reference: "ISTP-VA-021"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
@@ -1,25 +1,48 @@
 name: FillvalOutsideRange
 description: "FILLVAL must be outside the [VALIDMIN, VALIDMAX] range"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FILLVAL"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fillval"
 reference: "ISTP-VA-019"
 severity: ERROR
 suite: ISTP
 
 assertions:
-  - path: "variables/{var}/attributes/FILLVAL/values/0"
-    check: any_of
-    error_if_no_match: false
-    message: "{% if valid %}Attribute FILLVAL of {{ var }} is outside [VALIDMIN, VALIDMAX] range{% else %}Attribute FILLVAL of {{ var }} must be outside [VALIDMIN, VALIDMAX] range{% endif %}"
-    assertions:
-      - path: "variables/{var}/attributes/FILLVAL/values/0"
-        check: compare_to
-        operator: "<"
-        other_path: "variables/{var}/attributes/VALIDMIN/values/0"
-        error_if_no_match: false
-        message: ""
-      - path: "variables/{var}/attributes/FILLVAL/values/0"
-        check: compare_to
-        operator: ">"
-        other_path: "variables/{var}/attributes/VALIDMAX/values/0"
-        error_if_no_match: false
-        message: ""
+  # CDF time data types are exempt: their FILLVAL is standardized (the maximum
+  # time value, always outside any real range) and the underlying time values
+  # are not order-comparable, so the range check cannot be evaluated for them.
+  - check: if_then
+    if:
+      path: "variables/{var}/data_type"
+      check: not_in
+      values:
+        - TT2000
+        - CDFEPOCH
+        - CDFEPOCH16
+    then:
+      check: if_then
+      if:
+        path: "variables/{var}/attributes/FILLVAL/values/0"
+        check: exists
+      then:
+        check: any_of
+        message: "{% if valid %}Attribute FILLVAL of {var} is outside [VALIDMIN, VALIDMAX] range{% else %}Attribute FILLVAL of {var} must be outside [VALIDMIN, VALIDMAX] range (or NaN){% endif %}"
+        assertions:
+          - path: "variables/{var}/attributes/FILLVAL/values/0"
+            check: compare_to
+            operator: "<"
+            other_path: "variables/{var}/attributes/VALIDMIN/values/0"
+            error_if_no_match: false
+            message: ""
+          - path: "variables/{var}/attributes/FILLVAL/values/0"
+            check: compare_to
+            operator: ">"
+            other_path: "variables/{var}/attributes/VALIDMAX/values/0"
+            error_if_no_match: false
+            message: ""
+          # NaN (IEEE 754) is an allowed FILLVAL for CDF_REAL4/CDF_REAL8.
+          # NaN is the only value not equal to itself.
+          - path: "variables/{var}/attributes/FILLVAL/values/0"
+            check: compare_to
+            operator: "!="
+            other_path: "variables/{var}/attributes/FILLVAL/values/0"
+            error_if_no_match: false
+            message: ""

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
@@ -18,10 +18,17 @@ assertions:
         - CDFEPOCH
         - CDFEPOCH16
     then:
+      # Only meaningful when FILLVAL and both bounds are present; otherwise the
+      # range is undefined and the check is skipped (the missing VALIDMIN/VALIDMAX
+      # are reported by the data/support_data rules instead).
       check: if_then
       if:
-        path: "variables/{var}/attributes/FILLVAL/values/0"
-        check: exists
+        path: "variables/{var}/attributes"
+        check: contains_keys
+        keys:
+          - FILLVAL
+          - VALIDMIN
+          - VALIDMAX
       then:
         check: any_of
         message: "{% if valid %}Attribute FILLVAL of {var} is outside [VALIDMIN, VALIDMAX] range{% else %}Attribute FILLVAL of {var} must be outside [VALIDMIN, VALIDMAX] range (or NaN){% endif %}"

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FormPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FormPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: FormPtrReferences
 description: "FORM_PTR must reference an existing variable"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FORM_PTR"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#form_ptr"
 reference: "ISTP-VA-017"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
@@ -1,6 +1,6 @@
 name: FormatSpecifier
 description: "FORMAT must be a valid Fortran format specifier"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FORMAT"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#format"
 reference: "ISTP-VA-010"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: LablPtrReferences
 description: "LABL_PTR_1, LABL_PTR_2, LABL_PTR_3 must reference existing variables"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#LABL_PTR_1"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#labl_ptr_i"
 reference: "ISTP-VA-012"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisLength.yaml
@@ -1,6 +1,6 @@
 name: LablaxisLength
 description: "LABLAXIS should be short for axis labels (10 characters max)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#LABLAXIS"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#lablaxis"
 reference: "ISTP-VA-008"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisMaxLength.yaml
@@ -1,6 +1,6 @@
 name: LablaxisMaxLength
 description: "LABLAXIS must not exceed 20 characters (hard limit)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#LABLAXIS"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#lablaxis"
 reference: "ISTP-VA-022"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/MandatoryVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/MandatoryVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: MandatoryVariableAttributes
 description: "All variables must have required ISTP variable attributes"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html"
 reference: "ISTP-VA-001"
 severity: ERROR
 suite: ISTP
@@ -14,27 +14,38 @@ assertions:
       - VAR_TYPE
     message: "{% if valid %}{{ variable }} has all mandatory attributes{% else %}{{ variable }} is missing mandatory attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
 
-  - check: one_of
-    assertions:
-      - path: "variables/.*/attributes"
-        check: contains_keys
-        keys:
-          - FORMAT
-        message: "{% if valid %}{{ variable }} has FORMAT attribute{% else %}{{ variable }} must have either FORMAT or FORM_PTR attribute{% endif %}"
-      - path: "variables/.*/attributes"
-        check: contains_keys
-        keys:
-          - FORM_PTR
-        message: "{% if valid %}{{ variable }} has FORM_PTR attribute{% else %}{{ variable }} must have either FORMAT or FORM_PTR attribute{% endif %}"
-
+  # FORMAT/FORM_PTR required for all variables except defined CDF time data types.
   - check: if_then
     if:
-      path: "variables/.*/record_variance"
+      path: "variables/{var}/data_type"
+      check: not_in
+      values:
+        - TT2000
+        - CDFEPOCH
+        - CDFEPOCH16
+    then:
+      check: one_of
+      assertions:
+        - path: "variables/{var}/attributes"
+          check: contains_keys
+          keys:
+            - FORMAT
+          message: "{% if valid %}{{ variable }} has FORMAT attribute{% else %}{{ variable }} must have either FORMAT or FORM_PTR attribute{% endif %}"
+        - path: "variables/{var}/attributes"
+          check: contains_keys
+          keys:
+            - FORM_PTR
+          message: "{% if valid %}{{ variable }} has FORM_PTR attribute{% else %}{{ variable }} must have either FORMAT or FORM_PTR attribute{% endif %}"
+
+  # FILLVAL required for record-varying (time-varying) variables.
+  - check: if_then
+    if:
+      path: "variables/{var}/record_variance"
       check: comparison
       operator: "="
       value: true
     then:
-      path: "variables/.*/attributes"
+      path: "variables/{var}/attributes"
       check: contains_keys
       keys:
         - FILLVAL

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: MetadataVariableAttributes
 description: "Metadata variables must have required attributes per ISTP spec"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Metadata"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#metadata-variables"
 reference: "ISTP-VA-015"
 severity: ERROR
 suite: ISTP
@@ -8,28 +8,25 @@ suite: ISTP
 assertions:
   - check: if_then
     if:
-      path: "variables/.*/attributes/VAR_TYPE/values/[0-9]*"
+      path: "variables/{var}/attributes/VAR_TYPE/values/0"
       check: comparison
       operator: "="
       value: "metadata"
     then:
       check: all_of
       assertions:
-        - path: "variables/.*/attributes"
+        - path: "variables/{var}/attributes"
           check: contains_keys
           keys:
             - CATDESC
             - FIELDNAM
-            - VAR_TYPE
-          message: "{% if valid %}{{ variable }} has all required metadata attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
+          message: "{% if valid %}{{ variable }} has required metadata attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
         - check: any_of
           message: "Metadata variable must have FORMAT or FORM_PTR"
           assertions:
-            - path: "variables/.*/attributes/FORMAT"
+            - path: "variables/{var}/attributes/FORMAT"
               check: exists
-              error_if_no_match: false
               message: ""
-            - path: "variables/.*/attributes/FORM_PTR"
+            - path: "variables/{var}/attributes/FORM_PTR"
               check: exists
-              error_if_no_match: false
               message: ""

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ProposalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ProposalAttributes.yaml
@@ -1,6 +1,6 @@
 name: ProposalAttributes
 description: "ISTP proposal attributes (informational)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#coordinate_system"
 reference: "ISTP-INFO-001"
 severity: INFO
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ScalPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ScalPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: ScalPtrReferences
 description: "SCAL_PTR must reference an existing variable"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#SCAL_PTR"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#scal_ptr"
 reference: "ISTP-VA-018"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ScaleTypValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ScaleTypValues.yaml
@@ -1,6 +1,6 @@
 name: ScaleTypValues
 description: "SCALETYP should be 'linear' or 'log' for proper plotting"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#SCALETYP"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#scaletyp"
 reference: "ISTP-VA-013"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: SupportDataVariableAttributes
 description: "Support_data variables must have required attributes"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#support_data-variables"
 reference: "ISTP-VA-003"
 severity: ERROR
 suite: ISTP
@@ -8,52 +8,77 @@ suite: ISTP
 assertions:
   - check: if_then
     if:
-      path: "variables/.*/attributes/VAR_TYPE/values/[0-9]*"
+      path: "variables/{var}/attributes/VAR_TYPE/values/0"
       check: comparison
       operator: "="
       value: "support_data"
     then:
       check: all_of
       assertions:
-        - path: "variables/.*/attributes"
+        - path: "variables/{var}/attributes"
           check: contains_keys
           keys:
             - CATDESC
             - FIELDNAM
-            - VALIDMIN
-            - VALIDMAX
-          message: "{% if valid %}{{ variable }} has all required support_data attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
-        - check: any_of
-          message: "Support_data variable must have FORMAT or FORM_PTR"
-          assertions:
-            - path: "variables/.*/attributes/FORMAT"
-              check: exists
-              error_if_no_match: false
-              message: ""
-            - path: "variables/.*/attributes/FORM_PTR"
-              check: exists
-              error_if_no_match: false
-              message: ""
-        - check: any_of
-          message: "Support_data variable must have UNITS or UNIT_PTR"
-          assertions:
-            - path: "variables/.*/attributes/UNITS"
-              check: exists
-              error_if_no_match: false
-              message: ""
-            - path: "variables/.*/attributes/UNIT_PTR"
-              check: exists
-              error_if_no_match: false
-              message: ""
+          message: "{% if valid %}{{ variable }} has required support_data attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
         - check: any_of
           message: "Support_data variable must have LABLAXIS or LABL_PTR_1"
           assertions:
-            - path: "variables/.*/attributes/LABLAXIS"
+            - path: "variables/{var}/attributes/LABLAXIS"
               check: exists
-              error_if_no_match: false
               message: ""
-            - path: "variables/.*/attributes/LABL_PTR_1"
+            - path: "variables/{var}/attributes/LABL_PTR_1"
               check: exists
-              error_if_no_match: false
               message: ""
-
+        # FORMAT/FORM_PTR required, except for defined CDF time data types.
+        - check: if_then
+          if:
+            path: "variables/{var}/data_type"
+            check: not_in
+            values:
+              - TT2000
+              - CDFEPOCH
+              - CDFEPOCH16
+          then:
+            check: any_of
+            message: "Support_data variable must have FORMAT or FORM_PTR"
+            assertions:
+              - path: "variables/{var}/attributes/FORMAT"
+                check: exists
+                message: ""
+              - path: "variables/{var}/attributes/FORM_PTR"
+                check: exists
+                message: ""
+        # UNITS/UNIT_PTR required, except for CDF time data type variables.
+        - check: if_then
+          if:
+            path: "variables/{var}/data_type"
+            check: not_in
+            values:
+              - TT2000
+              - CDFEPOCH
+              - CDFEPOCH16
+          then:
+            check: any_of
+            message: "Support_data variable must have UNITS or UNIT_PTR"
+            assertions:
+              - path: "variables/{var}/attributes/UNITS"
+                check: exists
+                message: ""
+              - path: "variables/{var}/attributes/UNIT_PTR"
+                check: exists
+                message: ""
+        # VALIDMIN/VALIDMAX required only for record-varying (time-varying) support_data.
+        - check: if_then
+          if:
+            path: "variables/{var}/record_variance"
+            check: comparison
+            operator: "="
+            value: true
+          then:
+            path: "variables/{var}/attributes"
+            check: contains_keys
+            keys:
+              - VALIDMIN
+              - VALIDMAX
+            message: "{% if valid %}{{ variable }} has VALIDMIN/VALIDMAX{% else %}{{ variable }} (record-varying) missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/UnitPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/UnitPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: UnitPtrReferences
 description: "UNIT_PTR must reference an existing variable"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#UNIT_PTR"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#unit_ptr"
 reference: "ISTP-VA-016"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/UnitsNotEmpty.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/UnitsNotEmpty.yaml
@@ -1,6 +1,6 @@
 name: UnitsNotEmpty
-description: "UNITS attribute must not be empty (use 'unitless' or ' ' if no units)"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#UNITS"
+description: "UNITS attribute must not be empty (use a single blank space ' ' for no units)"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#units"
 reference: "ISTP-VA-009"
 severity: ERROR
 suite: ISTP
@@ -9,5 +9,5 @@ assertions:
   - path: "variables/.*/attributes/UNITS/values/[0-9]*"
     check: not_empty
     error_if_no_match: false
-    message: "{% if valid %}Attribute UNITS of {{ variable }} is not empty{% else %}Attribute UNITS of {{ variable }} cannot be empty - use 'unitless' or a single space{% endif %}"
+    message: "{% if valid %}Attribute UNITS of {{ variable }} is not empty{% else %}Attribute UNITS of {{ variable }} cannot be empty - use a single blank space ' ' for variables with no units{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/VarTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/VarTypeValues.yaml
@@ -1,6 +1,6 @@
 name: VarTypeValues
 description: "VAR_TYPE must be one of the allowed ISTP values"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#VAR_TYPE"
+url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#var_type"
 reference: "ISTP-VA-004"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/Variables/EpochAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochAttributes.yaml
@@ -1,39 +1,27 @@
 name: EpochAttributes
-description: "Epoch variable must have required ISTP attributes"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Epoch"
+description: "Time (epoch) variables must be support_data"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-002"
 severity: ERROR
 suite: ISTP
 
+# Keyed on the CDF time data type (not the variable name). The general
+# Mandatory/SupportData rules already enforce CATDESC/FIELDNAM/FILLVAL/
+# VALIDMIN/VALIDMAX with the correct CDF-time-type exemptions, so the only
+# epoch-specific structural requirement left here is VAR_TYPE = support_data.
 assertions:
-  - path: "variables/Epoch/attributes"
-    check: contains_keys
-    error_if_no_match: false
-    keys:
-      - CATDESC
-      - FIELDNAM
-      - FILLVAL
-      - LABLAXIS
-      - UNITS
-      - VALIDMIN
-      - VALIDMAX
-      - VAR_TYPE
-    message: "{% if valid %}Epoch has all required attributes{% else %}Epoch missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
-
-  # Epoch VAR_TYPE should be support_data
-  - path: "variables/Epoch/attributes/VAR_TYPE/values/[0-9]*"
-    check: comparison
-    operator: "="
-    value: "support_data"
-    error_if_no_match: false
-    message: "{% if valid %}Attribute VAR_TYPE of Epoch has value '{{ value }}'{% else %}Attribute VAR_TYPE of Epoch has value '{{ value }}', expected 'support_data'{% endif %}"
-
-  # Epoch MONOTON should be INCREASE (or rarely DECREASE)
-  - path: "variables/Epoch/attributes/MONOTON/values/[0-9]*"
-    check: in
-    error_if_no_match: false
-    values:
-      - INCREASE
-      - DECREASE
-    message: "{% if valid %}Attribute MONOTON of Epoch has value '{{ value }}'{% else %}Attribute MONOTON of Epoch has value '{{ value }}', expected 'INCREASE' or 'DECREASE'{% endif %}"
-
+  - check: if_then
+    if:
+      path: "variables/{var}/data_type"
+      check: in
+      values:
+        - TT2000
+        - CDFEPOCH
+        - CDFEPOCH16
+    then:
+      path: "variables/{var}/attributes/VAR_TYPE/values/0"
+      check: comparison
+      operator: "="
+      value: "support_data"
+      error_if_no_match: false
+      message: "{% if valid %}time variable {var} has VAR_TYPE='support_data'{% else %}time variable {var} should have VAR_TYPE='support_data' (got '{{ value }}'){% endif %}"

--- a/src/astralint/suites/ISTP/rules/Variables/EpochRecommendedAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochRecommendedAttributes.yaml
@@ -1,16 +1,49 @@
 name: EpochRecommendedAttributes
-description: "Epoch variable should have recommended ISTP attributes"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Epoch"
+description: "Time (epoch) variables should carry recommended time-documentation attributes"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-003"
 severity: WARNING
 suite: ISTP
 
 assertions:
-  - path: "variables/Epoch/attributes"
-    check: contains_keys
+  # MONOTON is recommended for every time (epoch) variable, regardless of name.
+  - check: if_then
+    if:
+      path: "variables/{var}/data_type"
+      check: in
+      values:
+        - TT2000
+        - CDFEPOCH
+        - CDFEPOCH16
+    then:
+      path: "variables/{var}/attributes"
+      check: contains_keys
+      keys:
+        - MONOTON
+      message: "{% if valid %}time variable {var} has MONOTON{% else %}time variable {var} should have a MONOTON attribute (INCREASE or DECREASE){% endif %}"
+
+  # If MONOTON is present, its value must be INCREASE or DECREASE.
+  - path: "variables/.*/attributes/MONOTON/values/[0-9]*"
+    check: in
     error_if_no_match: false
-    keys:
-      - MONOTON
-      - TIME_BASE
-      - TIME_SCALE
-    message: "{% if valid %}Epoch has all recommended attributes{% else %}Epoch missing recommended attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
+    values:
+      - INCREASE
+      - DECREASE
+    message: "{% if valid %}Attribute MONOTON of {{ variable }} has value '{{ value }}'{% else %}Attribute MONOTON of {{ variable }} has value '{{ value }}', expected 'INCREASE' or 'DECREASE'{% endif %}"
+
+  # TIME_BASE/TIME_SCALE are recommended for CDF_EPOCH/CDF_EPOCH16, but not needed
+  # for CDF_TIME_TT2000 (which is internally fully defined).
+  - check: if_then
+    if:
+      path: "variables/{var}/data_type"
+      check: in
+      values:
+        - CDFEPOCH
+        - CDFEPOCH16
+    then:
+      path: "variables/{var}/attributes"
+      check: contains_keys
+      keys:
+        - TIME_BASE
+        - TIME_SCALE
+      message: "{% if valid %}time variable {var} documents TIME_BASE/TIME_SCALE{% else %}CDF_EPOCH variable {var} should document {{ missing_keys | join(', ') }}{% endif %}"

--- a/src/astralint/suites/ISTP/rules/Variables/EpochVariable.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochVariable.yaml
@@ -1,23 +1,20 @@
 name: EpochVariable
-description: "Files should contain an Epoch variable for time tagging"
-url: "https://spdf.gsfc.nasa.gov/istp_guide/variables.html#Epoch"
+description: "Dataset must contain at least one CDF time (epoch) variable"
+url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-001"
-severity: WARNING
+severity: ERROR
 suite: ISTP
 
 assertions:
-  # Check that Epoch variable exists
-  - path: "variables/Epoch"
-    check: exists
-    message: "File must contain an 'Epoch' variable for time tagging"
-
-  # Epoch should be CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000
-  - path: "variables/Epoch/data_type"
-    check: in
-    error_if_no_match: false
-    values:
-      - CDFEPOCH
-      - CDFEPOCH16
-      - TT2000
-    message: "Epoch variable must be of type CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000"
-
+  # An epoch (time) variable is Required. The ISTP Guidelines do NOT mandate the
+  # name "Epoch" ("any other meaningful name" is allowed), so the check keys on
+  # the CDF time data type, not the variable name.
+  - check: any_match
+    message: "{% if valid %}dataset contains a CDF time (epoch) variable{% else %}dataset must contain at least one variable of a CDF time data type (CDF_EPOCH, CDF_EPOCH16, or CDF_TIME_TT2000){% endif %}"
+    assertion:
+      path: "variables/.*/data_type"
+      check: in
+      values:
+        - CDFEPOCH
+        - CDFEPOCH16
+        - TT2000

--- a/src/astralint/suites/ISTP/suite.yaml
+++ b/src/astralint/suites/ISTP/suite.yaml
@@ -1,4 +1,4 @@
 name: ISTP
-url: "https://github.com/IHDE-Alliance/ISTP_metadata/blob/main/ISTP_metadata_guidelines/README.md"
+url: "https://istp-metadata.readthedocs.io/en/latest/"
 rules_lookup_dir: "rules"
 description: "ISTP metadata validation suite"

--- a/tests/test_cdaweb_suite.py
+++ b/tests/test_cdaweb_suite.py
@@ -1,0 +1,77 @@
+"""CDAWeb conformance suite: inherits ISTP and tightens CDAWeb-required rules."""
+
+from pathlib import Path
+
+import astralint
+from astralint.base.conformance_suite import ConformanceSuite, get_suite
+from astralint.base.file import Attribute, DataType, File
+from astralint.base.validation_result import ValidationResultGroup
+from astralint.base.yaml_rules.yaml_rule import load_yaml_rule
+
+SUITES_DIR = Path(astralint.__file__).parent / "suites"
+
+
+def suite(name: str) -> ConformanceSuite:
+    s = get_suite(name)
+    assert s is not None, f"suite {name} should be registered"
+    return s
+
+
+def attr(name: str, values: list) -> Attribute:
+    return Attribute(name=name, data_type=[DataType.CHAR], shape=[len(values)], values=values)
+
+
+def make_file(global_attrs: dict) -> File:
+    return File(
+        extension="cdf",
+        filename="test.cdf",
+        compression="NONE",
+        attributes=global_attrs,
+        variables={},
+    )
+
+
+def _severity(suite_name: str, reference: str) -> str:
+    return next(r.severity.value for r in suite(suite_name).rules if r.reference == reference)
+
+
+def test_cdaweb_inherits_all_istp_rules_and_adds_its_own():
+    istp_refs = {r.reference for r in suite("ISTP").rules}
+    cdaweb_refs = {r.reference for r in suite("CDAWeb").rules}
+    assert istp_refs <= cdaweb_refs, "CDAWeb must inherit every ISTP rule"
+    assert "CDAWEB-GA-001" in cdaweb_refs, "CDAWeb must add its own entry-limit rule"
+
+
+def test_cdaweb_promotes_required_attrs_to_error():
+    assert _severity("ISTP", "ISTP-GA-016") == "WARNING"
+    assert _severity("CDAWeb", "ISTP-GA-016") == "ERROR"
+
+
+def test_severity_override_changes_finding_severity():
+    """A file missing Instrument_type/Mission_group is a warning under ISTP but an
+    error under the CDAWeb profile."""
+    f = make_file({})
+
+    def has(suite_name: str, sev: str) -> bool:
+        rule = next(r for r in suite(suite_name).rules if r.reference == "ISTP-GA-016")
+        result = rule.check(f)
+        assert isinstance(result, ValidationResultGroup)
+        return result.count_by_severity()[sev] > 0
+
+    assert has("ISTP", "WARNING")
+    assert has("CDAWeb", "ERROR")
+
+
+def test_cdaweb_entry_limit_flags_more_than_five():
+    rule = load_yaml_rule(SUITES_DIR / "CDAWeb" / "rules" / "CDAWebEntryLimits.yaml")
+    too_many = make_file({"Instrument_type": attr("Instrument_type", ["Particles (space)"] * 6)})
+    assert not rule.check(too_many).valid
+    ok = make_file({"Instrument_type": attr("Instrument_type", ["Particles (space)"] * 5)})
+    assert rule.check(ok).valid
+
+
+def test_suite_construction_is_idempotent():
+    """Regression: loading a suite twice must not duplicate its rules."""
+    first = len(suite("ISTP").rules)
+    second = len(suite("ISTP").rules)
+    assert first == second

--- a/tests/test_cdaweb_suite.py
+++ b/tests/test_cdaweb_suite.py
@@ -2,8 +2,14 @@
 
 from pathlib import Path
 
+import pytest
+
 import astralint
-from astralint.base.conformance_suite import ConformanceSuite, get_suite
+from astralint.base.conformance_suite import (
+    ConformanceSuite,
+    _ConformanceSuiteProtocolCtor,
+    get_suite,
+)
 from astralint.base.file import Attribute, DataType, File
 from astralint.base.validation_result import ValidationResultGroup
 from astralint.base.yaml_rules.yaml_rule import load_yaml_rule
@@ -75,3 +81,15 @@ def test_suite_construction_is_idempotent():
     first = len(suite("ISTP").rules)
     second = len(suite("ISTP").rules)
     assert first == second
+
+
+def test_invalid_severity_override_raises_contextual_error():
+    ctor = _ConformanceSuiteProtocolCtor(
+        name="BadSuite",
+        rules_lookup_dir="/nonexistent",
+        severity_overrides={"ISTP-GA-016": "CRITICAL"},
+        description="x",
+        url="x",
+    )
+    with pytest.raises(ValueError, match="BadSuite"):
+        ctor()

--- a/tests/test_cdf_istp.py
+++ b/tests/test_cdf_istp.py
@@ -1,5 +1,8 @@
 import os
 
+import pytest
+import requests
+
 from astralint.base import get_suite, load_file
 
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
@@ -21,7 +24,11 @@ def test_remote_file_in_istp_suite():
     sample_url = (
         "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/ac_h5_swi_00000000_v01.cdf"
     )
-    sample = load_file(sample_url)
+    try:
+        sample = load_file(sample_url)
+    except (requests.exceptions.RequestException, OSError) as exc:
+        # Network-dependent test: a CI runner outage must not be a hard failure.
+        pytest.skip(f"remote resource unreachable: {exc}")
     assert sample is not None, "Validation should return results."
     results = suite.run(sample)
     assert results is not None, "Validation should return results."

--- a/tests/test_istp_rule_corrections.py
+++ b/tests/test_istp_rule_corrections.py
@@ -318,6 +318,22 @@ def test_fillval_range_check_exempts_time_types():
     assert rule.check(f).valid
 
 
+def test_fillval_range_check_skipped_without_bounds():
+    """When VALIDMIN/VALIDMAX are absent the range is undefined, so the check must
+    be skipped rather than reporting a 'comparison target not found' false error."""
+    f = make_file(
+        variables={
+            "B": var(
+                "B",
+                "data",
+                {"FILLVAL": attr("FILLVAL", [-1e31], DataType.FLOAT64)},  # no VALIDMIN/MAX
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "FillvalOutsideRange")
+    assert rule.check(f).valid
+
+
 def test_fillval_nan_is_allowed():
     f = make_file(
         variables={

--- a/tests/test_istp_rule_corrections.py
+++ b/tests/test_istp_rule_corrections.py
@@ -1,0 +1,445 @@
+"""Reproducer tests for the ISTP rule-correctness review.
+
+Each test pins a specific finding from the audit of the ISTP suite against the
+IHDE-Alliance ISTP_metadata guidelines (docs/source/03-05). They are written to
+fail against the pre-review rules and pass once the corresponding fix lands.
+"""
+
+from pathlib import Path
+
+import astralint
+from astralint.base.file import Attribute, DataType, File, Variable
+from astralint.base.yaml_rules.yaml_rule import load_yaml_rule
+
+RULES_DIR = Path(astralint.__file__).parent / "suites" / "ISTP" / "rules"
+
+
+def load_rule(category: str, name: str):
+    return load_yaml_rule(RULES_DIR / category / f"{name}.yaml")
+
+
+def attr(name: str, values: list, dtype: DataType = DataType.CHAR) -> Attribute:
+    return Attribute(name=name, data_type=[dtype], shape=[len(values)], values=values)
+
+
+def var(
+    name: str,
+    var_type: str | None = None,
+    attrs: dict | None = None,
+    data_type: DataType = DataType.FLOAT64,
+    record_variance: bool = True,
+    shape: list[int] | None = None,
+) -> Variable:
+    attributes = dict(attrs or {})
+    if var_type is not None:
+        attributes["VAR_TYPE"] = attr("VAR_TYPE", [var_type])
+    return Variable(
+        name=name,
+        attributes=attributes,
+        compression="NONE",
+        data_type=data_type,
+        record_variance=record_variance,
+        shape=shape or [1],
+    )
+
+
+def make_file(global_attrs: dict | None = None, variables: dict | None = None) -> File:
+    return File(
+        extension="cdf",
+        filename="test.cdf",
+        compression="NONE",
+        attributes=dict(global_attrs or {}),
+        variables=dict(variables or {}),
+    )
+
+
+_FULL_DATA_ATTRS = {
+    "CATDESC": attr("CATDESC", ["A fine data variable"]),
+    "FIELDNAM": attr("FIELDNAM", ["Data"]),
+    "DEPEND_0": attr("DEPEND_0", ["Epoch"]),
+    "DISPLAY_TYPE": attr("DISPLAY_TYPE", ["time_series"]),
+    "FORMAT": attr("FORMAT", ["F10.2"]),
+    "LABLAXIS": attr("LABLAXIS", ["B"]),
+    "UNITS": attr("UNITS", ["nT"]),
+    "VALIDMIN": attr("VALIDMIN", [0.0], DataType.FLOAT64),
+    "VALIDMAX": attr("VALIDMAX", [100.0], DataType.FLOAT64),
+    "FILLVAL": attr("FILLVAL", [-1e31], DataType.FLOAT64),
+}
+
+
+# --- Engine: per-variable conditional correlation (DataVariableAttributes) ----
+
+
+def test_data_variable_rule_runs_on_mixed_type_file():
+    """A data variable missing DEPEND_0 must be flagged even when other variables
+    have a different VAR_TYPE (the if_then must correlate per-variable)."""
+    broken = dict(_FULL_DATA_ATTRS)
+    del broken["DEPEND_0"]
+    f = make_file(
+        variables={
+            "Flux": var("Flux", "data", broken),
+            "Flux_labels": var("Flux_labels", "metadata", data_type=DataType.CHAR),
+        }
+    )
+    rule = load_rule("VariableAttributes", "DataVariableAttributes")
+    assert not rule.check(f).valid
+
+
+def test_data_variable_rule_passes_compliant_data_in_mixed_file():
+    f = make_file(
+        variables={
+            "Flux": var("Flux", "data", _FULL_DATA_ATTRS),
+            "Flux_labels": var("Flux_labels", "metadata", data_type=DataType.CHAR),
+        }
+    )
+    rule = load_rule("VariableAttributes", "DataVariableAttributes")
+    assert rule.check(f).valid
+
+
+# --- SupportData: RV-only VALIDMIN/MAX and time-type UNITS/FORMAT exemption ---
+
+
+def test_support_data_validmin_only_required_when_record_varying():
+    """Time-invariant support_data does not require VALIDMIN/VALIDMAX."""
+    f = make_file(
+        variables={
+            "Energy": var(
+                "Energy",
+                "support_data",
+                {
+                    "CATDESC": attr("CATDESC", ["Energy table"]),
+                    "FIELDNAM": attr("FIELDNAM", ["Energy"]),
+                    "FORMAT": attr("FORMAT", ["F10.2"]),
+                    "UNITS": attr("UNITS", ["keV"]),
+                    "LABLAXIS": attr("LABLAXIS", ["E"]),
+                },
+                record_variance=False,
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "SupportDataVariableAttributes")
+    assert rule.check(f).valid
+
+
+def test_support_data_rv_missing_validmin_fails():
+    f = make_file(
+        variables={
+            "Energy": var(
+                "Energy",
+                "support_data",
+                {
+                    "CATDESC": attr("CATDESC", ["Energy table"]),
+                    "FIELDNAM": attr("FIELDNAM", ["Energy"]),
+                    "FORMAT": attr("FORMAT", ["F10.2"]),
+                    "UNITS": attr("UNITS", ["keV"]),
+                    "LABLAXIS": attr("LABLAXIS", ["E"]),
+                },
+                record_variance=True,
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "SupportDataVariableAttributes")
+    assert not rule.check(f).valid
+
+
+def test_support_data_time_type_exempt_from_units_and_format():
+    """An epoch support_data variable (CDF time type) needs neither UNITS nor FORMAT."""
+    f = make_file(
+        variables={
+            "Epoch": var(
+                "Epoch",
+                "support_data",
+                {
+                    "CATDESC": attr("CATDESC", ["Time"]),
+                    "FIELDNAM": attr("FIELDNAM", ["Epoch"]),
+                    "LABLAXIS": attr("LABLAXIS", ["Epoch"]),
+                    "VALIDMIN": attr("VALIDMIN", [0], DataType.TT2000),
+                    "VALIDMAX": attr("VALIDMAX", [1], DataType.TT2000),
+                },
+                data_type=DataType.TT2000,
+                record_variance=True,
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "SupportDataVariableAttributes")
+    assert rule.check(f).valid
+
+
+# --- Metadata rule actually runs ---------------------------------------------
+
+
+def test_metadata_variable_missing_format_fails():
+    f = make_file(
+        variables={
+            "Labels": var(
+                "Labels",
+                "metadata",
+                {
+                    "CATDESC": attr("CATDESC", ["Component labels"]),
+                    "FIELDNAM": attr("FIELDNAM", ["Labels"]),
+                },
+                data_type=DataType.CHAR,
+                record_variance=False,
+            ),
+            "Flux": var("Flux", "data", _FULL_DATA_ATTRS),
+        }
+    )
+    rule = load_rule("VariableAttributes", "MetadataVariableAttributes")
+    assert not rule.check(f).valid
+
+
+# --- MandatoryVariableAttributes: RV FILLVAL + time-type FORMAT exemption -----
+
+
+def test_rv_variable_missing_fillval_flagged_in_mixed_file():
+    rv_attrs = {
+        "CATDESC": attr("CATDESC", ["Counts"]),
+        "FIELDNAM": attr("FIELDNAM", ["Counts"]),
+        "VAR_TYPE": attr("VAR_TYPE", ["data"]),
+        "FORMAT": attr("FORMAT", ["I10"]),
+    }
+    static_attrs = {
+        "CATDESC": attr("CATDESC", ["Static"]),
+        "FIELDNAM": attr("FIELDNAM", ["Static"]),
+        "VAR_TYPE": attr("VAR_TYPE", ["support_data"]),
+        "FORMAT": attr("FORMAT", ["I10"]),
+    }
+    f = make_file(
+        variables={
+            "Counts": var("Counts", attrs=rv_attrs, record_variance=True),
+            "Static": var("Static", attrs=static_attrs, record_variance=False),
+        }
+    )
+    rule = load_rule("VariableAttributes", "MandatoryVariableAttributes")
+    assert not rule.check(f).valid
+
+
+def test_time_type_variable_exempt_from_format():
+    """CDF time-type variables do not require FORMAT/FORM_PTR."""
+    f = make_file(
+        variables={
+            "Epoch": var(
+                "Epoch",
+                "support_data",
+                {
+                    "CATDESC": attr("CATDESC", ["Time"]),
+                    "FIELDNAM": attr("FIELDNAM", ["Epoch"]),
+                },
+                data_type=DataType.TT2000,
+                record_variance=True,
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "MandatoryVariableAttributes")
+    # No FORMAT/FORM_PTR, but Epoch is a time type -> the FORMAT requirement must not fire.
+    # (FILLVAL is still required for RV; provide it so we isolate the FORMAT exemption.)
+    f.variables["Epoch"].attributes["FILLVAL"] = attr(
+        "FILLVAL", [-9223372036854775808], DataType.TT2000
+    )
+    assert rule.check(f).valid
+
+
+# --- Global attribute format regexes -----------------------------------------
+
+
+def test_data_type_accepts_hyphen_and_lowercase():
+    for value in ["L2-Summary>level 2 summary", "l2-gms-62ms>gms data"]:
+        f = make_file({"Data_type": attr("Data_type", [value])})
+        rule = load_rule("GlobalAttributes", "DataTypeFormat")
+        assert rule.check(f).valid, value
+
+
+def test_logical_file_id_accepts_hyphen_in_descriptor():
+    f = make_file(
+        {"Logical_file_id": attr("Logical_file_id", ["psp_isois_l2-summary_20180928_v07"])}
+    )
+    rule = load_rule("GlobalAttributes", "LogicalFileIdFormat")
+    assert rule.check(f).valid
+
+
+def test_project_accepts_space_and_lowercase_short_name():
+    for value in ["STSP Cluster>Solar Terrestrial Science Programmes, Cluster", "CDAWxx>Workshop"]:
+        f = make_file({"Project": attr("Project", [value])})
+        rule = load_rule("GlobalAttributes", "ProjectFormat")
+        assert rule.check(f).valid, value
+
+
+def test_project_format_is_warning():
+    rule = load_rule("GlobalAttributes", "ProjectFormat")
+    assert rule.severity.value == "WARNING"
+
+
+# --- Controlled lists ---------------------------------------------------------
+
+
+def test_instrument_type_accepts_dust_and_debris():
+    f = make_file({"Instrument_type": attr("Instrument_type", ["Dust and Debris"])})
+    rule = load_rule("GlobalAttributes", "InstrumentTypeValues")
+    assert rule.check(f).valid
+
+
+# --- Messages / semantics -----------------------------------------------------
+
+
+def test_units_single_space_passes_and_message_drops_unitless():
+    f = make_file(variables={"B": var("B", "data", {"UNITS": attr("UNITS", [" "])})})
+    rule = load_rule("VariableAttributes", "UnitsNotEmpty")
+    assert rule.check(f).valid
+    src = (RULES_DIR / "VariableAttributes" / "UnitsNotEmpty.yaml").read_text()
+    assert "unitless" not in src
+
+
+def test_text_short_but_nonempty_passes():
+    f = make_file({"TEXT": attr("TEXT", ["Short text."])})
+    rule = load_rule("GlobalAttributes", "TextNotEmpty")
+    assert rule.check(f).valid
+
+
+def test_fillval_range_check_exempts_time_types():
+    """CDF time variables use a standardized FILLVAL and tt2000_t is not ordered,
+    so the [VALIDMIN, VALIDMAX] range check must not fire on them."""
+    f = make_file(
+        variables={
+            "Epoch": var(
+                "Epoch",
+                "support_data",
+                {
+                    # FILLVAL deliberately *inside* [VALIDMIN, VALIDMAX]: would fail
+                    # for a numeric variable, but time types are exempt.
+                    "FILLVAL": attr("FILLVAL", [50], DataType.TT2000),
+                    "VALIDMIN": attr("VALIDMIN", [0], DataType.TT2000),
+                    "VALIDMAX": attr("VALIDMAX", [100], DataType.TT2000),
+                },
+                data_type=DataType.TT2000,
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "FillvalOutsideRange")
+    assert rule.check(f).valid
+
+
+def test_fillval_nan_is_allowed():
+    f = make_file(
+        variables={
+            "B": var(
+                "B",
+                "data",
+                {
+                    "FILLVAL": attr("FILLVAL", [float("nan")], DataType.FLOAT64),
+                    "VALIDMIN": attr("VALIDMIN", [0.0], DataType.FLOAT64),
+                    "VALIDMAX": attr("VALIDMAX", [100.0], DataType.FLOAT64),
+                },
+            )
+        }
+    )
+    rule = load_rule("VariableAttributes", "FillvalOutsideRange")
+    assert rule.check(f).valid
+
+
+# --- Hard-vs-soft: CDAWeb-required globals ------------------------------------
+
+
+def _istp_required_globals() -> dict:
+    return {
+        k: attr(k, [v])
+        for k, v in {
+            "Data_type": "L2>Level 2",
+            "Data_version": "1",
+            "Descriptor": "ABC>A B C",
+            "Logical_file_id": "a_b_c_20200101_v01",
+            "Logical_source": "a_b_c",
+            "Logical_source_description": "desc",
+            "PI_affiliation": "Org",
+            "PI_name": "J. Doe",
+            "Source_name": "ABC>A B C",
+            "TEXT": "A long enough description of the data.",
+        }.items()
+    }
+
+
+def test_mandatory_globals_no_longer_require_cdaweb_attrs():
+    """Instrument_type and Mission_group are CDAWeb-required, not ISTP-mandatory."""
+    f = make_file(_istp_required_globals())
+    rule = load_rule("GlobalAttributes", "MandatoryGlobalAttributes")
+    assert rule.check(f).valid
+
+
+def test_cdaweb_required_rule_flags_missing_attrs():
+    f = make_file(_istp_required_globals())
+    rule = load_rule("GlobalAttributes", "CDAWebRequiredGlobalAttributes")
+    assert not rule.check(f).valid
+    assert rule.severity.value == "WARNING"
+
+
+def test_recommended_globals_include_file_naming_convention():
+    src = (RULES_DIR / "GlobalAttributes" / "RecommendedGlobalAttributes.yaml").read_text()
+    assert "File_naming_convention" in src
+
+
+# --- Epoch rules are name-agnostic (key on CDF time data type, not name) -----
+
+
+def test_epoch_variable_accepts_non_epoch_named_time_var():
+    """A CDF time variable under any name satisfies the epoch requirement."""
+    f = make_file(
+        variables={
+            "mms1_asp_epoch": var(
+                "mms1_asp_epoch",
+                "support_data",
+                {"CATDESC": attr("CATDESC", ["Time"]), "FIELDNAM": attr("FIELDNAM", ["Epoch"])},
+                data_type=DataType.TT2000,
+            )
+        }
+    )
+    rule = load_rule("Variables", "EpochVariable")
+    assert rule.check(f).valid
+
+
+def test_epoch_variable_missing_time_var_fails():
+    f = make_file(variables={"B": var("B", "data", data_type=DataType.FLOAT64)})
+    rule = load_rule("Variables", "EpochVariable")
+    assert not rule.check(f).valid
+
+
+def test_epoch_attributes_apply_to_any_time_var_regardless_of_name():
+    """A time variable with the wrong VAR_TYPE is flagged even if not named Epoch."""
+    f = make_file(
+        variables={
+            "time": var(
+                "time",
+                "data",  # wrong: an epoch/time variable should be support_data
+                {"CATDESC": attr("CATDESC", ["t"]), "FIELDNAM": attr("FIELDNAM", ["t"])},
+                data_type=DataType.TT2000,
+            )
+        }
+    )
+    rule = load_rule("Variables", "EpochAttributes")
+    assert not rule.check(f).valid
+
+
+def test_epoch_recommended_tt2000_does_not_require_time_base():
+    """TIME_BASE/TIME_SCALE are not needed for CDF_TIME_TT2000."""
+    f = make_file(
+        variables={
+            "tt": var(
+                "tt",
+                "support_data",
+                {"MONOTON": attr("MONOTON", ["INCREASE"])},
+                data_type=DataType.TT2000,
+            )
+        }
+    )
+    rule = load_rule("Variables", "EpochRecommendedAttributes")
+    assert rule.check(f).valid
+
+
+# --- URLs point to the ReadTheDocs guidelines --------------------------------
+
+
+def test_all_rule_urls_point_to_readthedocs():
+    bad = []
+    for path in RULES_DIR.rglob("*.yaml"):
+        rule = load_yaml_rule(path)
+        if not rule.url.startswith("https://istp-metadata.readthedocs.io/"):
+            bad.append(path.name)
+    assert not bad, f"rules with non-RTD url: {bad}"

--- a/tests/test_istp_rule_corrections.py
+++ b/tests/test_istp_rule_corrections.py
@@ -449,6 +449,30 @@ def test_epoch_recommended_tt2000_does_not_require_time_base():
     assert rule.check(f).valid
 
 
+# --- any_match existential semantics -----------------------------------------
+
+
+def test_any_match_fails_on_zero_matches_even_when_lenient():
+    """An existential quantifier must fail when nothing matches, regardless of a
+    lenient error_if_no_match on the wrapped assertion."""
+    from astralint.base.validation_result import Severity
+    from astralint.base.yaml_rules.assertions.combinations import AnyMatch
+
+    f = make_file(variables={"B": var("B", "data")})
+    am = AnyMatch.model_validate(
+        {
+            "check": "any_match",
+            "assertion": {
+                "path": "variables/Nonexistent/data_type",
+                "check": "in",
+                "values": ["TT2000"],
+                "error_if_no_match": False,
+            },
+        }
+    )
+    assert not am.evaluate(f, Severity.ERROR).valid
+
+
 # --- URLs point to the ReadTheDocs guidelines --------------------------------
 
 


### PR DESCRIPTION
Careful review of the **ISTP suite** against the freshly-synced [IHDE-Alliance ISTP_metadata](https://istp-metadata.readthedocs.io/) guidelines, plus a dedicated **CDAWeb** profile. Fixes false positives, silently-skipped checks, and Required-vs-Recommended (hard-vs-soft) misclassifications. The `resources/ISTP_metadata` submodule is bumped to upstream tip and is now treated as the source of truth.

## Engine (`assertions/combinations.py`)
- **`if_then`/`if_then_else` are now capture-aware.** When the `if` path contains a `{capture}` (e.g. `{var}`), the condition and `then`/`else` branches are evaluated **once per binding**, with the capture interpolated into all paths/messages. This fixes a **silent no-op**: `if variables/.*/…/VAR_TYPE == "data"` was only satisfied when *every* variable shared that type (wildcard groups are valid only if all matches pass), so `DataVariableAttributes`, `SupportDataVariableAttributes` and `MetadataVariableAttributes` were `SKIPPED` on every mixed-type (i.e. real) file.
- **New `any_match` combinator** — passes if *at least one* wildcard match satisfies the wrapped assertion (existential, vs the default "all must pass").

## Variable rules
- The conditional variable rules are rewritten with `{var}` so they actually run per-variable, and now encode the guideline's qualifiers: `VALIDMIN`/`VALIDMAX` only for RV `support_data`; `UNITS`/`FORMAT` exempt for CDF time types; `FILLVAL` for RV variables.
- **Epoch rules made name-agnostic** — ISTP does *not* mandate the name `Epoch` (any meaningful name is allowed). `EpochVariable` now requires ≥1 variable of a CDF time data type; `EpochAttributes`/`EpochRecommendedAttributes` key on the time data type, not the name.
- `FillvalOutsideRange`: per-variable; allows `NaN` (`FILLVAL != FILLVAL`); exempts CDF time types (standardized fill, and `tt2000_t` is not order-comparable → was a `TypeError` false positive).

## Global rules
- `Instrument_type` & `Mission_group` are *"required by CDAWeb"*, not ISTP-Required → moved out of `MandatoryGlobalAttributes` (ERROR) into a dedicated `CDAWebRequiredGlobalAttributes` (WARNING). `ProjectFormat` ERROR → WARNING.
- Regex fixes that rejected official guideline example values: `Data_type` & `Logical_file_id` allow hyphen/lowercase (`L2-Summary`, `psp_isois_l2-summary_…`); `Project` allows space/lowercase (`STSP Cluster`, `CDAWxx`).
- `InstrumentTypeValues`: add missing `Dust and Debris`. Recommended globals: add `File_naming_convention`. `UnitsNotEmpty`: stop suggesting `'unitless'` (spec says use a blank space). `TextNotEmpty`: drop the arbitrary 20-char minimum.

## CDAWeb conformance profile (new)
- New **CDAWeb** suite that **inherits ISTP** and tightens the CDAWeb-required rules, keeping ISTP itself faithful to the spec.
- Suite inheritance can now declare **`severity_overrides`** (keyed by rule reference) in `suite.yaml`; CDAWeb promotes `ISTP-GA-016` (`Instrument_type`/`Mission_group`) from WARNING → ERROR.
- New CDAWeb-specific rule `CDAWebEntryLimits`: at most five entries for `Instrument_type` / `HTTP_LINK` / `LINK_TEXT` / `LINK_TITLE`.
- **Fix:** rule loading is now idempotent — `register_yaml_rule` replaces a rule of the same name instead of appending, so (re)loading a suite directly and as a parent no longer duplicates its rules (a second `get_suite("ISTP")` previously returned 84 rules instead of 42).

## Docs / refs
- All rule URLs repointed to the ReadTheDocs guidelines; broken `suite.yaml` link fixed; per-variable `if_then` behavior documented in `docs/assertions.md`; CDAWeb suite added to the README.

## Tests
- 30 reproducer tests across `tests/test_istp_rule_corrections.py` and `tests/test_cdaweb_suite.py` (one per fix, written failing-first). Full suite **270 passing**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)