### PR TITLE
chore(wasm): upgrade Pyodide to 314.0.0 for the demo and CI

### DIFF
--- a/.github/workflows/wasm_tests.yml
+++ b/.github/workflows/wasm_tests.yml
@@ -31,10 +31,10 @@ jobs:
         FORCE_COLOR: 3
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
         allow-prereleases: true
     - name: Install Node.js
       uses: actions/setup-node@v6
@@ -52,7 +52,7 @@ jobs:
     - name: Download pyodide wheel artifact
       uses: pyodide/pyodide-actions/download-pyodide@v2
       with:
-        version: '0.29.3'
+        version: '314.0.0'
         to: pyodide-dist
 
     - name: restore astralint wheel artifact
@@ -71,7 +71,7 @@ jobs:
 
     - name: install pyodide-py
       run: |
-        python -m pip install pyodide-py==0.29.3
+        python -m pip install pyodide-py==314.0.0
 
     - name: Install pytest-pyodide
       run: python -m pip install pytest-pyodide

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -477,7 +477,7 @@
         </footer>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v314.0.0/full/pyodide.js"></script>
     <script>
         let pyodide = null;
 

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -12,7 +12,10 @@ try:
     @copy_files_to_pyodide(
         file_list=[(_FILE_PATH, _DEST_PATH)], install_wheels=True, recurse_directories=True
     )
-    @run_in_pyodide(packages=["micropip", "pycdfpp"])
+    # pycdfpp ships emscripten wheels on PyPI but is not part of the Pyodide
+    # distribution, so it cannot be loadPackage'd; it is resolved from PyPI by
+    # micropip when the astralint wheel is installed (install_wheels=True).
+    @run_in_pyodide(packages=["micropip"])
     async def test_import_astralint(selenium):
         from astralint.base import list_all_suites
 


### PR DESCRIPTION
Upgrades the demo and the wasm CI to the latest Pyodide (**314.0.0** — Python 3.14.2, Emscripten 5.0.3, ABI `pyemscripten_2026_0`).

- **demo** (`docs/demo/index.html`): load Pyodide `v314.0.0` from the CDN.
- **wasm CI** (`.github/workflows/wasm_tests.yml`): `download-pyodide` 314.0.0, `pyodide-py==314.0.0`, host Python bumped to 3.14 (`pyodide-py` 314 requires `>=3.14`).
- **test_wasm**: install `pycdfpp` via micropip rather than `loadPackage` — it ships emscripten wheels on PyPI but isn't part of the Pyodide distribution (the newer pytest-pyodide surfaces the previously-silent `loadPackage` failure).

The dependency constraints needed for Pyodide 314 already landed on `main` in #20 (`astropy>=7.0.1`; `pycdfpp>=0.8.5` resolves to the right wheel per platform — 0.10.0 on 314), and **astralint v0.6.0 is published to PyPI** with them, so:
- no pyproject change is needed here, and
- the demo (which installs astralint from PyPI via `micropip`) now works on Pyodide 314.

Validated: the wasm `test` job runs the locally-built wheel on Pyodide 314 and passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)