### PR TITLE
fix(deps): widen emscripten astropy pin to allow newer Pyodide

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ classifiers = [
 # ---- Main dependencies ----
 
 dependencies = [
-    "astropy<=7.0.1; sys_platform == 'emscripten'",
+    # emscripten: Pyodide bundles astropy (7.0.1 on 0.29.x, 7.2.0 on 314) — accept
+    # both so the constraint is satisfiable on the current and the next Pyodide.
+    "astropy>=7.0.1; sys_platform == 'emscripten'",
     "astropy>=7.2.0; sys_platform != 'emscripten'",
     "cyclopts>=4.5.2",
     "jinja2>=3.1.0",


### PR DESCRIPTION
Minimal dependency fix and prerequisite for the **v0.5.1** release that lets the in-browser demo run on the latest Pyodide (314.0.0). Net change vs main: one line.

- The emscripten astropy pin was an **upper** bound (`<=7.0.1`) tied to the old Pyodide distribution, which blocks installing on a newer Pyodide that bundles a newer astropy. Replace it with a **lower** bound (`>=7.0.1`): satisfiable on Pyodide 0.29.x (astropy 7.0.1) **and** Pyodide 314 (astropy 7.2.0).
- `pycdfpp` stays at `>=0.8.5` on purpose: micropip already selects the right wheel per platform (0.8.6 on Pyodide 0.29.x, 0.10.0 on Pyodide 314). Pinning `>=0.10.0` would drop the older Pyodide ABI (0.10.0 only ships `pyemscripten_2025_0/2026_0` wheels), which is why it must not go in this release.

The demo installs `astralint` from PyPI via `micropip`, so the live demo needs this on PyPI before it can run on Pyodide 314. The Pyodide-314 demo + CI bump is in #19 (separate).

Native: full suite passes, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)