### PR TITLE
fix(istp): correct ReadTheDocs rule URLs (missing source/ path)

### DIFF
--- a/src/astralint/suites/CDAWeb/rules/CDAWebEntryLimits.yaml
+++ b/src/astralint/suites/CDAWeb/rules/CDAWebEntryLimits.yaml
@@ -1,6 +1,6 @@
 name: CDAWebEntryLimits
 description: "CDAWeb allows at most five entries for multi-valued instrument/link attributes"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#instrument_type"
 reference: "CDAWEB-GA-001"
 severity: ERROR
 suite: CDAWeb

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/CDAWebRequiredGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/CDAWebRequiredGlobalAttributes.yaml
@@ -1,6 +1,6 @@
 name: CDAWebRequiredGlobalAttributes
 description: "Global attributes that are ISTP-recommended but required by CDAWeb"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#instrument_type"
 reference: "ISTP-GA-016"
 # Recommended by ISTP, required for ingestion into CDAWeb -> warning, not error.
 severity: WARNING

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
@@ -1,6 +1,6 @@
 name: DOIFormat
 description: "DOI must use the standard https://doi.org/ format"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#doi"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#doi"
 reference: "ISTP-GA-014"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
@@ -1,6 +1,6 @@
 name: DataTypeFormat
 description: "Data_type must follow ISTP convention: ABBREV>Full_description"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#data_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#data_type"
 reference: "ISTP-GA-006"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
@@ -1,6 +1,6 @@
 name: DataVersionFormat
 description: "Data_version must be a valid version string"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#data_version"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#data_version"
 reference: "ISTP-GA-005"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
@@ -1,6 +1,6 @@
 name: DescriptorFormat
 description: "Descriptor must follow ISTP convention: ABBREV>Full_description"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#descriptor"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#descriptor"
 reference: "ISTP-GA-008"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
@@ -1,6 +1,6 @@
 name: DisciplineValues
 description: "Discipline should use standard ISTP values"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#discipline"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#discipline"
 reference: "ISTP-GA-009"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
@@ -1,6 +1,6 @@
 name: GenerationDateFormat
 description: "Generation_date must use yyyymmdd format"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#generation_date"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#generation_date"
 reference: "ISTP-GA-015"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
@@ -1,6 +1,6 @@
 name: InstrumentTypeValues
 description: "Instrument_type should use standard ISTP values"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#instrument_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#instrument_type"
 reference: "ISTP-GA-010"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
@@ -1,6 +1,6 @@
 name: LinkCountConsistency
 description: "HTTP_LINK, LINK_TEXT, and LINK_TITLE must have the same number of entries"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#link_text-link_title-http_link"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#link_text-link_title-http_link"
 reference: "ISTP-GA-013"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
@@ -1,6 +1,6 @@
 name: LogicalFileIdFormat
 description: "Logical_file_id must match the filename and include date and version"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#logical_file_id"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#logical_file_id"
 reference: "ISTP-GA-004"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
@@ -1,6 +1,6 @@
 name: LogicalSourceFormat
 description: "Logical_source must follow ISTP naming convention: source_descriptor_datatype"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#logical_source"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#logical_source"
 reference: "ISTP-GA-003"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/MandatoryGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/MandatoryGlobalAttributes.yaml
@@ -1,6 +1,6 @@
 name: MandatoryGlobalAttributes
 description: "All mandatory global attributes must be present (ISTP/SPDF required)"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html"
 reference: "ISTP-GA-001"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
@@ -1,6 +1,6 @@
 name: ProjectFormat
 description: "Project must follow ISTP convention"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#project"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#project"
 reference: "ISTP-GA-012"
 # Project is a *Recommended* attribute, so a malformed value is a warning, not an error.
 severity: WARNING

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/RecommendedGlobalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/RecommendedGlobalAttributes.yaml
@@ -1,6 +1,6 @@
 name: RecommendedGlobalAttributes
 description: "Recommended global attributes should be present for better data discoverability"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html"
 reference: "ISTP-GA-002"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
@@ -1,6 +1,6 @@
 name: SourceNameFormat
 description: "Source_name must follow ISTP convention: ABBREV>Full_Name"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#source_name"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#source_name"
 reference: "ISTP-GA-007"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
@@ -1,6 +1,6 @@
 name: TextNotEmpty
 description: "TEXT attribute must contain meaningful description of the data"
-url: "https://istp-metadata.readthedocs.io/en/latest/03_metadata-global-attributes.html#text"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/03_metadata-global-attributes.html#text"
 reference: "ISTP-GA-011"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescLength.yaml
@@ -1,6 +1,6 @@
 name: CatdescLength
 description: "CATDESC should be descriptive but concise (80 characters max per ISTP)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#catdesc"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#catdesc"
 reference: "ISTP-VA-006"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/CatdescMaxLength.yaml
@@ -1,6 +1,6 @@
 name: CatdescMaxLength
 description: "CATDESC must not exceed 120 characters (hard limit)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#catdesc"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#catdesc"
 reference: "ISTP-VA-020"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: DataVariableAttributes
 description: "Data variables (VAR_TYPE=data) must have additional required attributes"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#data-variables"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#data-variables"
 reference: "ISTP-VA-002"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DeltaReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DeltaReferences.yaml
@@ -1,6 +1,6 @@
 name: DeltaReferences
 description: "DELTA_PLUS_VAR and DELTA_MINUS_VAR must reference existing variables"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#delta_plus_var-delta_minus_var"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#delta_plus_var-delta_minus_var"
 reference: "ISTP-VA-014"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DependReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DependReferences.yaml
@@ -1,6 +1,6 @@
 name: DependReferences
 description: "DEPEND_0, DEPEND_1, DEPEND_2, DEPEND_3 must reference existing variables"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#depend_0"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#depend_0"
 reference: "ISTP-VA-011"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
@@ -1,6 +1,6 @@
 name: DisplayTypeValues
 description: "DISPLAY_TYPE should use standard ISTP values"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#display_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#display_type"
 reference: "ISTP-VA-005"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamLength.yaml
@@ -1,6 +1,6 @@
 name: FieldnamLength
 description: "FIELDNAM should be concise for plot labels (30 characters max)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fieldnam"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#fieldnam"
 reference: "ISTP-VA-007"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FieldnamMaxLength.yaml
@@ -1,6 +1,6 @@
 name: FieldnamMaxLength
 description: "FIELDNAM must not exceed 50 characters (hard limit)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fieldnam"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#fieldnam"
 reference: "ISTP-VA-021"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FillvalOutsideRange.yaml
@@ -1,6 +1,6 @@
 name: FillvalOutsideRange
 description: "FILLVAL must be outside the [VALIDMIN, VALIDMAX] range"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#fillval"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#fillval"
 reference: "ISTP-VA-019"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FormPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FormPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: FormPtrReferences
 description: "FORM_PTR must reference an existing variable"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#form_ptr"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#form_ptr"
 reference: "ISTP-VA-017"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
@@ -1,6 +1,6 @@
 name: FormatSpecifier
 description: "FORMAT must be a valid Fortran format specifier"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#format"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#format"
 reference: "ISTP-VA-010"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: LablPtrReferences
 description: "LABL_PTR_1, LABL_PTR_2, LABL_PTR_3 must reference existing variables"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#labl_ptr_i"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#labl_ptr_i"
 reference: "ISTP-VA-012"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisLength.yaml
@@ -1,6 +1,6 @@
 name: LablaxisLength
 description: "LABLAXIS should be short for axis labels (10 characters max)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#lablaxis"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#lablaxis"
 reference: "ISTP-VA-008"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisMaxLength.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/LablaxisMaxLength.yaml
@@ -1,6 +1,6 @@
 name: LablaxisMaxLength
 description: "LABLAXIS must not exceed 20 characters (hard limit)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#lablaxis"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#lablaxis"
 reference: "ISTP-VA-022"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/MandatoryVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/MandatoryVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: MandatoryVariableAttributes
 description: "All variables must have required ISTP variable attributes"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html"
 reference: "ISTP-VA-001"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: MetadataVariableAttributes
 description: "Metadata variables must have required attributes per ISTP spec"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#metadata-variables"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#metadata-variables"
 reference: "ISTP-VA-015"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ProposalAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ProposalAttributes.yaml
@@ -1,6 +1,6 @@
 name: ProposalAttributes
 description: "ISTP proposal attributes (informational)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#coordinate_system"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#coordinate_system"
 reference: "ISTP-INFO-001"
 severity: INFO
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ScalPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ScalPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: ScalPtrReferences
 description: "SCAL_PTR must reference an existing variable"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#scal_ptr"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#scal_ptr"
 reference: "ISTP-VA-018"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/ScaleTypValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/ScaleTypValues.yaml
@@ -1,6 +1,6 @@
 name: ScaleTypValues
 description: "SCALETYP should be 'linear' or 'log' for proper plotting"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#scaletyp"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#scaletyp"
 reference: "ISTP-VA-013"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
@@ -1,6 +1,6 @@
 name: SupportDataVariableAttributes
 description: "Support_data variables must have required attributes"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#support_data-variables"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#support_data-variables"
 reference: "ISTP-VA-003"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/UnitPtrReferences.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/UnitPtrReferences.yaml
@@ -1,6 +1,6 @@
 name: UnitPtrReferences
 description: "UNIT_PTR must reference an existing variable"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#unit_ptr"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#unit_ptr"
 reference: "ISTP-VA-016"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/UnitsNotEmpty.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/UnitsNotEmpty.yaml
@@ -1,6 +1,6 @@
 name: UnitsNotEmpty
 description: "UNITS attribute must not be empty (use a single blank space ' ' for no units)"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#units"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#units"
 reference: "ISTP-VA-009"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/VarTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/VarTypeValues.yaml
@@ -1,6 +1,6 @@
 name: VarTypeValues
 description: "VAR_TYPE must be one of the allowed ISTP values"
-url: "https://istp-metadata.readthedocs.io/en/latest/05_metadata-variable-attributes.html#var_type"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/05_metadata-variable-attributes.html#var_type"
 reference: "ISTP-VA-004"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/Variables/EpochAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochAttributes.yaml
@@ -1,6 +1,6 @@
 name: EpochAttributes
 description: "Time (epoch) variables must be support_data"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-002"
 severity: ERROR
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/Variables/EpochRecommendedAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochRecommendedAttributes.yaml
@@ -1,6 +1,6 @@
 name: EpochRecommendedAttributes
 description: "Time (epoch) variables should carry recommended time-documentation attributes"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-003"
 severity: WARNING
 suite: ISTP

--- a/src/astralint/suites/ISTP/rules/Variables/EpochVariable.yaml
+++ b/src/astralint/suites/ISTP/rules/Variables/EpochVariable.yaml
@@ -1,6 +1,6 @@
 name: EpochVariable
 description: "Dataset must contain at least one CDF time (epoch) variable"
-url: "https://istp-metadata.readthedocs.io/en/latest/04_metadata-variables.html#epoch"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/04_metadata-variables.html#epoch"
 reference: "ISTP-VAR-001"
 severity: ERROR
 suite: ISTP


### PR DESCRIPTION
The ISTP rule `url` links pointed to `…/en/latest/0X_*.html`, but the guideline pages are published under `…/en/latest/**source/**0X_*.html` (the Sphinx toctree in `docs/index.rst` lists them as `source/0X_…`). So every rule's doc link 404'd.

Insert the missing `source/` path segment in all 43 rule `url` fields, e.g.:
`…/en/latest/source/03_metadata-global-attributes.html#data_type`

Anchors are unchanged — MyST (`myst_heading_anchors`) uses GitHub-style header slugs, which already matched. The suite index link (`…/en/latest/`) was already correct and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)