### PR TITLE
feat(demo): add the CDAWeb suite to the online demo

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -427,6 +427,12 @@
                     <small>NASA ISTP Guidelines</small>
                 </label>
 
+                <input type="radio" name="suite" id="suite-cdaweb" value="CDAWeb">
+                <label for="suite-cdaweb">
+                    <strong>CDAWeb</strong><br>
+                    <small>CDAWeb ingestion profile (ISTP + required attributes)</small>
+                </label>
+
                 <input type="radio" name="suite" id="suite-pds4" value="PDS4">
                 <label for="suite-pds4">
                     <strong>PDS4</strong><br>


### PR DESCRIPTION
The **CDAWeb** conformance profile shipped in v0.6.0 (it inherits ISTP and promotes the CDAWeb-required attributes to errors), but the online demo still only offered ISTP / PDS4 / SOLARNET.

Adds a **CDAWeb** radio next to ISTP. The demo already passes the selected value straight to `get_suite()`, and the CDAWeb suite is part of the published wheel, so no other change is required.

Part of the pre-v0.6.1 fixes (with #21, the ReadTheDocs URL fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)