### PR TITLE
feat(resolver): filename-derived global attribute fixes + fixability roadmap (Phase 1b #1)

### DIFF
--- a/docs/superpowers/specs/2026-06-20-resolver-fixability-roadmap.md
+++ b/docs/superpowers/specs/2026-06-20-resolver-fixability-roadmap.md
@@ -1,0 +1,62 @@
+# Resolver Fixability Roadmap — ISTP coverage map
+
+**Status:** roadmap (living). Phase 1 (PR #25) shipped the deterministic foundation; this maps every ISTP rule to how a fix can be produced, defining the path toward proposing a disposition for *almost every* error.
+
+**Disposition legend:** **AUTO** = deterministic, safe to auto-apply · **STAGED** = computable but needs a human OK (lossy/ambiguous/partial) · **DATA** = needs variable data arrays (the File model is metadata-only today) · **USER** = irreducibly human (external IDs, prose, controlled vocabulary). ✅ = shipped in PR #25.
+
+## Principle
+
+Every error should get *a disposition* — AUTO, STAGED, or USER ("needs your input") — so nothing is silently unaddressable, even when the value can't be computed. The "fix hint" in `lint` follows coverage and reports honest auto / staged / user counts.
+
+## Global attributes
+
+| Rule | Sev | Attribute | Class | Disposition |
+|---|---|---|---|---|
+| GA-004 LogicalFileIdFormat | E | Logical_file_id | filename | **AUTO** (= filename stem; regex `^[a-z0-9_-]+_\d{8}(_v\d+)?$`) |
+| GA-003 LogicalSourceFormat | E | Logical_source | filename | **AUTO** (= stem minus `_YYYYMMDD[_vN]`; regex `source_descriptor_datatype`) |
+| GA-005 DataVersionFormat | E | Data_version | filename | **AUTO** (from `_vNN` → numeric `^\d+(\.\d+)*$`) |
+| GA-008 DescriptorFormat | E | Descriptor | filename+prose | **STAGED** (abbrev from filename; `>Full description` is human — regex `ABBREV>.+`) |
+| GA-006 DataTypeFormat | E | Data_type | filename+prose | **STAGED** (same `ABBREV>.+` shape) |
+| GA-007 SourceNameFormat | E | Source_name | filename+prose | **STAGED** (mission abbrev from filename; full name human) |
+| GA-015 GenerationDateFormat | W | Generation_date | date | **AUTO** (reformat existing value to `yyyymmdd`, else today) |
+| GA-001 MandatoryGlobalAttributes | E | (set) | mixed | AUTO/STAGED for the filename ones above; **USER** for PI_name, PI_affiliation, TEXT, Project, Acknowledgement, Mission_group |
+| GA-013 LinkCountConsistency | E | HTTP_LINK/LINK_* | consistency | STAGED (counts must match; which links is intent) |
+| GA-002 RecommendedGlobalAttributes | W | DOI, spase_ID, Time_resolution | user/data | USER (DOI/spase); DATA (Time_resolution from epoch cadence) |
+| GA-009/010/016 Discipline/Instrument_type/Mission_group | W | controlled vocab | enum | USER (offer closest-in-set suggestion) |
+| GA-011/012/014 TEXT/Project/DOI | E/W | prose / ID | user | USER |
+
+## Variable attributes
+
+| Rule | Sev | Attribute | Class | Disposition |
+|---|---|---|---|---|
+| VA-013 ScaleTypValues | W | SCALETYP | type | ✅ AUTO |
+| VA-004 VarTypeValues | E | VAR_TYPE | graph | ✅ AUTO |
+| VA-005 DisplayTypeValues | W | DISPLAY_TYPE | graph | ✅ AUTO |
+| VA-011/012/014/016/017/018 *PtrReferences | E | DEPEND/LABL/DELTA/UNIT/FORM/SCAL_PTR | reference | ✅ STAGED |
+| VA-001/002/003/015 Mandatory/Data/Support/Metadata attrs | E | VAR_TYPE, DEPEND_0, FILLVAL, … | graph+type | ✅ partial (graph/type subset); USER for UNITS/CATDESC/FIELDNAM |
+| VA-019 FillvalOutsideRange | E | FILLVAL vs VALIDMIN/MAX | type | AUTO (set standard ISTP fill, which is out of range) |
+| VA-022 LablaxisMaxLength | E | LABLAXIS | truncate | STAGED (lossy) |
+| VA-020 CatdescMaxLength | E | CATDESC | truncate | STAGED |
+| VA-021 FieldnamMaxLength | E | FIELDNAM | truncate | STAGED |
+| VA-008 LablaxisLength | W | LABLAXIS | truncate | STAGED |
+| VA-010 FormatSpecifier | W | FORMAT | data | DATA (from type + observed magnitude) |
+| VA-009 UnitsNotEmpty | E | UNITS | physical | USER (never fabricate units) |
+| VA-006/007 Catdesc/Fieldnam length | W | CATDESC/FIELDNAM | prose | USER |
+
+## Variables
+
+| Rule | Sev | Class | Disposition |
+|---|---|---|---|
+| VAR-002 EpochAttributes (VAR_TYPE=support_data) | E | graph | **AUTO** — resolver exists; just wire the trigger |
+| VAR-003 EpochRecommendedAttributes (MONOTON, TIME_BASE) | W | data+type | DATA (MONOTON); AUTO (TIME_BASE default) |
+| VAR-001 EpochVariable (≥1 time var) | E | structural | USER (can't fabricate a time axis) |
+
+## Phase-1b priority order
+
+1. **Filename-derived globals — AUTO subset** (GA-004 Logical_file_id, GA-003 Logical_source, GA-005 Data_version) + a new `filename` ReferenceSource and an ISTP-filename parser. Highest real-world value (the common CDAWeb / mission non-compliance). *This is the slice being built now.*
+2. **Filename globals — STAGED subset** (GA-008/006/007 Descriptor/Data_type/Source_name): propose the `ABBREV>` skeleton from the filename, flag the description for the human.
+3. **Free graph wins**: wire VAR-002 and the VA-001 VAR_TYPE path into the existing graph resolvers (few registry lines).
+4. **Generation_date** (GA-015) + **FillvalOutsideRange** (VA-019) — small deterministic resolvers.
+5. **Truncation set** (VA-008/020/021/022) — one staged resolver.
+6. **DATA tier** (FORMAT, MONOTON, Time_resolution) — requires extending the codec/File model to carry variable data; separate, larger milestone.
+7. **USER-flagging**: give the irreducible rules a "needs your input" disposition so the `lint` fix-hint can show honest auto/staged/user counts.

--- a/src/astralint/astralint.py
+++ b/src/astralint/astralint.py
@@ -299,7 +299,7 @@ def fix(
     with open(path, "rb") as f:
         cdf_bytes = f.read()
 
-    convergence, fixed = converge(cdf_bytes, checker, max_iter=max_iter)
+    convergence, fixed = converge(cdf_bytes, checker, max_iter=max_iter, filename=path.name)
 
     if convergence.applied:
         console.print(f"[bold]Proposed/applied fixes ({len(convergence.applied)}):[/]")

--- a/src/astralint/resolver/apply.py
+++ b/src/astralint/resolver/apply.py
@@ -41,9 +41,11 @@ def _abstract_type(var) -> DataType:
 
 def _apply_one(cdf, fix: Fix) -> None:
     if fix.scope == Scope.GLOBAL:
-        # Phase 1 emits no global fixes, but keep the path honest.
+        # One CHAR entry: entries_values is a flat list of per-entry values.
         if fix.action == "add":
-            cdf.add_attribute(fix.attribute, [[fix.value]], [pycdfpp.DataType.CDF_CHAR])
+            cdf.add_attribute(fix.attribute, [fix.value], [pycdfpp.DataType.CDF_CHAR])
+        else:  # set: overwrite the existing global attribute's entries
+            cdf.attributes[fix.attribute].set_values([fix.value], [pycdfpp.DataType.CDF_CHAR])
         return
 
     # Re-fetch the variable handle every time: pycdfpp wrappers hold references

--- a/src/astralint/resolver/loop.py
+++ b/src/astralint/resolver/loop.py
@@ -27,15 +27,22 @@ def _failure_signature(results: ValidationResultGroup) -> frozenset[tuple[str, s
     return frozenset((reference, leaf.target) for reference, leaf in _iter_failures(results))
 
 
-def _load(cdf_bytes: bytes) -> File:
+def _load(cdf_bytes: bytes, filename: str | None = None) -> File:
     result = CdfCodec.load(cdf_bytes)
     if result is None:
         raise ValueError("Failed to parse CDF bytes")
+    # The byte round-trip drops the original filename (the codec uses a
+    # placeholder); restore it so filename-derived resolvers can run.
+    if filename is not None:
+        result.filename = filename
     return result
 
 
 def converge(
-    cdf_bytes: bytes, suite: ConformanceSuite, max_iter: int = 10
+    cdf_bytes: bytes,
+    suite: ConformanceSuite,
+    max_iter: int = 10,
+    filename: str | None = None,
 ) -> tuple[ConvergenceReport, bytes]:
     applied: list[Fix] = []
     iterations = 0
@@ -43,7 +50,7 @@ def converge(
     prev_signature: frozenset[tuple[str, str]] | None = None
 
     while iterations < max_iter:
-        file = _load(cdf_bytes)
+        file = _load(cdf_bytes, filename)
         results = suite.run(file)
         if not results.has_errors():
             stopped = "converged"
@@ -66,7 +73,7 @@ def converge(
 
     # Recompute staged suggestions against the FINAL file state so they reflect
     # what still needs review after all auto-fixes (not a stale pre-mutation set).
-    final_file = _load(cdf_bytes)
+    final_file = _load(cdf_bytes, filename)
     final = suite.run(final_file)
     staged = [f for f in resolve(final_file, final.failures_only()) if not f.auto]
     report = ConvergenceReport(

--- a/src/astralint/resolver/models.py
+++ b/src/astralint/resolver/models.py
@@ -13,6 +13,7 @@ class Scope(str, Enum):  # noqa: UP042
 class ReferenceSource(str, Enum):  # noqa: UP042
     TYPE_RULE = "type_rule"
     GRAPH_RULE = "graph_rule"
+    FILENAME = "filename_convention"
     USER = "user"
 
 

--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -1,4 +1,9 @@
 from .models import ApplyPolicy, ReferenceSource, ResolverEntry, Scope
+from .sources.filename import (
+    data_version_from_filename,
+    logical_file_id_from_filename,
+    logical_source_from_filename,
+)
 from .sources.graph_rules import depend0_finder, display_type_infer, var_type_infer
 from .sources.pointers import dangling_pointer_suggestion
 from .sources.type_rules import fillval_by_type, scaletyp_default
@@ -77,6 +82,36 @@ REGISTRY: list[ResolverEntry] = [
         auto_apply=ApplyPolicy.IF_UNIQUE,
         confidence_default=0.8,
         triggers=["ISTP-VA-002", "ISTP-VA-005"],
+    ),
+    # Filename-derived global attributes (AUTO when the filename matches the
+    # ISTP convention; the resolver returns None otherwise). Triggers cover both
+    # the malformed-value rule and the missing-attribute rule (ISTP-GA-001).
+    ResolverEntry(
+        attribute="Logical_file_id",
+        scope=Scope.GLOBAL,
+        sources=[ReferenceSource.FILENAME],
+        resolver=logical_file_id_from_filename,
+        auto_apply=ApplyPolicy.ALWAYS,
+        confidence_default=0.9,
+        triggers=["ISTP-GA-004", "ISTP-GA-001"],
+    ),
+    ResolverEntry(
+        attribute="Logical_source",
+        scope=Scope.GLOBAL,
+        sources=[ReferenceSource.FILENAME],
+        resolver=logical_source_from_filename,
+        auto_apply=ApplyPolicy.ALWAYS,
+        confidence_default=0.9,
+        triggers=["ISTP-GA-003", "ISTP-GA-001"],
+    ),
+    ResolverEntry(
+        attribute="Data_version",
+        scope=Scope.GLOBAL,
+        sources=[ReferenceSource.FILENAME],
+        resolver=data_version_from_filename,
+        auto_apply=ApplyPolicy.ALWAYS,
+        confidence_default=0.9,
+        triggers=["ISTP-GA-005", "ISTP-GA-001"],
     ),
     *[_pointer_entry(attr, triggers) for attr, triggers in _POINTER_TRIGGERS.items()],
 ]

--- a/src/astralint/resolver/sources/filename.py
+++ b/src/astralint/resolver/sources/filename.py
@@ -1,0 +1,52 @@
+import re
+
+from ...base.file import File
+from ...base.validation_result import ValidationResult
+from ..models import ResolverOutput
+
+# ISTP filename stem: <logical_source>_<YYYYMMDD>[_vN]. logical_source is greedy
+# so the trailing date (and optional version) anchor the match.
+_STEM_RE = re.compile(r"^(?P<logical_source>[a-z0-9_-]+)_(?P<date>\d{8})(?:_v(?P<version>\d+))?$")
+
+
+def _stem(filename: str) -> str:
+    return filename[:-4] if filename.lower().endswith(".cdf") else filename
+
+
+def _match(file: File) -> re.Match | None:
+    return _STEM_RE.match(_stem(file.filename))
+
+
+def logical_file_id_from_filename(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    if _match(file) is None:
+        return None
+    return ResolverOutput(
+        value=_stem(file.filename),
+        provenance_note=f"derived from filename '{file.filename}'",
+    )
+
+
+def logical_source_from_filename(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    match = _match(file)
+    if match is None:
+        return None
+    return ResolverOutput(
+        value=match.group("logical_source"),
+        provenance_note=f"derived from filename '{file.filename}'",
+    )
+
+
+def data_version_from_filename(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    match = _match(file)
+    if match is None or match.group("version") is None:
+        return None
+    return ResolverOutput(
+        value=match.group("version"),
+        provenance_note=f"version from filename '{file.filename}'",
+    )

--- a/tests/test_resolver_apply.py
+++ b/tests/test_resolver_apply.py
@@ -100,3 +100,34 @@ def test_numeric_value_and_type_uses_native_cdf_type():
     assert float32_type == pycdfpp.DataType.CDF_FLOAT
     _, epoch_type = _numeric_value_and_type(DataType.CDFEPOCH, -1e31)
     assert epoch_type == pycdfpp.DataType.CDF_EPOCH
+
+
+def _global_fix(attribute, value, action):
+    return Fix(
+        target_path=f"attributes/{attribute}",
+        variable=None,
+        attribute=attribute,
+        scope=Scope.GLOBAL,
+        action=action,
+        value=value,
+        source=ReferenceSource.FILENAME,
+        confidence=1.0,
+        provenance_note="test",
+        auto=True,
+    )
+
+
+def test_apply_global_add():
+    out = apply_fixes(_bytes(), [_global_fix("NEW_GLOBAL_ATTR", "hello", "add")])
+    # Bind the CDF to a local: pycdfpp attribute views read into the CDF's C++
+    # memory, so the loaded CDF must outlive the iteration.
+    cdf = pycdfpp.load(out)
+    assert [x for x in cdf.attributes["NEW_GLOBAL_ATTR"]] == ["hello"]
+
+
+def test_apply_global_set_overwrites():
+    cdf = pycdfpp.load(_CDF)
+    gname = next(iter(cdf.attributes))  # an existing global attribute
+    out = apply_fixes(_bytes(), [_global_fix(gname, "OVERWRITTEN", "set")])
+    reloaded = pycdfpp.load(out)
+    assert [x for x in reloaded.attributes[gname]] == ["OVERWRITTEN"]

--- a/tests/test_resolver_filename.py
+++ b/tests/test_resolver_filename.py
@@ -1,0 +1,55 @@
+from astralint.base.file import File
+from astralint.resolver.sources.filename import (
+    data_version_from_filename,
+    logical_file_id_from_filename,
+    logical_source_from_filename,
+)
+
+
+def _file(filename: str) -> File:
+    return File(extension="cdf", filename=filename, compression="NONE", attributes={}, variables={})
+
+
+def test_logical_file_id_is_the_stem():
+    f = _file("solo_l2_rpw-lfr-surv-swf-b_20220221_v02.cdf")
+    out = logical_file_id_from_filename(f, None, "Logical_file_id", None)
+    assert out is not None
+    assert out.value == "solo_l2_rpw-lfr-surv-swf-b_20220221_v02"
+
+
+def test_logical_source_drops_date_and_version():
+    f = _file("solo_l2_rpw-lfr-surv-swf-b_20220221_v02.cdf")
+    out = logical_source_from_filename(f, None, "Logical_source", None)
+    assert out is not None
+    assert out.value == "solo_l2_rpw-lfr-surv-swf-b"
+
+
+def test_data_version_from_vNN():
+    f = _file("solo_l2_rpw-lfr-surv-swf-b_20220221_v02.cdf")
+    out = data_version_from_filename(f, None, "Data_version", None)
+    assert out is not None
+    assert out.value == "02"
+
+
+def test_multi_token_source_matches():
+    f = _file("mms1_asp2_srvy_l1b_stat_00000000_v01.cdf")
+    src = logical_source_from_filename(f, None, "Logical_source", None)
+    fid = logical_file_id_from_filename(f, None, "Logical_file_id", None)
+    assert src is not None and src.value == "mms1_asp2_srvy_l1b_stat"
+    assert fid is not None and fid.value == "mms1_asp2_srvy_l1b_stat_00000000_v01"
+
+
+def test_non_conventional_filename_returns_none():
+    f = _file("random_file.cdf")
+    assert logical_file_id_from_filename(f, None, "Logical_file_id", None) is None
+    assert logical_source_from_filename(f, None, "Logical_source", None) is None
+    assert data_version_from_filename(f, None, "Data_version", None) is None
+
+
+def test_no_version_token_still_derives_id_and_source():
+    f = _file("solo_l2_rpw_20220221.cdf")  # no _vNN
+    assert data_version_from_filename(f, None, "Data_version", None) is None
+    fid = logical_file_id_from_filename(f, None, "Logical_file_id", None)
+    src = logical_source_from_filename(f, None, "Logical_source", None)
+    assert fid is not None and fid.value == "solo_l2_rpw_20220221"
+    assert src is not None and src.value == "solo_l2_rpw"

--- a/tests/test_resolver_loop.py
+++ b/tests/test_resolver_loop.py
@@ -99,3 +99,23 @@ def test_failure_signature_distinguishes_rules_on_same_target():
     assert ("ISTP-VA-001", "v") in sig
     assert ("ISTP-VA-004", "v") in sig
     assert len(sig) == 2
+
+
+def test_converge_fixes_malformed_logical_file_id_from_filename():
+    fname = "mms1_asp2_srvy_l1b_stat_00000000_v01.cdf"
+    cdf = pycdfpp.load(_CDF)
+    if "Logical_file_id" in cdf.attributes:
+        cdf.attributes["Logical_file_id"].set_values(["BADID"], [pycdfpp.DataType.CDF_CHAR])
+    else:
+        cdf.add_attribute("Logical_file_id", [["BADID"]], [pycdfpp.DataType.CDF_CHAR])
+    broken = bytes(pycdfpp.save(cdf))
+
+    suite = get_suite("ISTP")
+    assert suite is not None
+    report, out = converge(broken, suite, max_iter=5, filename=fname)
+
+    assert any(f.attribute == "Logical_file_id" for f in report.applied)
+    fixed = pycdfpp.load(out)
+    assert [x for x in fixed.attributes["Logical_file_id"]][
+        0
+    ] == "mms1_asp2_srvy_l1b_stat_00000000_v01"

--- a/tests/test_resolver_registry.py
+++ b/tests/test_resolver_registry.py
@@ -27,3 +27,12 @@ def test_depend0_has_both_a_finder_and_a_dangling_entry():
     triggers = {t for e in depend0 for t in e.triggers}
     assert "ISTP-VA-002" in triggers  # missing -> finder
     assert "ISTP-VA-011" in triggers  # dangling -> suggestion
+
+
+def test_registry_has_filename_global_entries():
+    from astralint.resolver.models import ReferenceSource, Scope
+
+    filename_entries = [e for e in REGISTRY if ReferenceSource.FILENAME in e.sources]
+    attrs = {e.attribute for e in filename_entries}
+    assert {"Logical_file_id", "Logical_source", "Data_version"} <= attrs
+    assert all(e.scope == Scope.GLOBAL for e in filename_entries)


### PR DESCRIPTION
## Summary

First Phase-1b slice on top of the merged resolver engine (#25), plus the **ISTP fixability roadmap** that scopes the path to auto-proposing a disposition for (almost) every error.

**Filename-derived global attributes (AUTO).** A new `FILENAME` `ReferenceSource` + an ISTP-filename parser derive the identity globals from the file name when it matches the convention `logical_source_YYYYMMDD[_vN]`:
- `Logical_file_id` ← the filename stem
- `Logical_source` ← stem minus date/version
- `Data_version` ← the `vNN` token

Resolvers return `None` on non-conventional filenames (never fabricate). Registry entries are GLOBAL-scope and trigger on both the malformed-value rules (GA-003/004/005) and the missing-attribute rule (GA-001).

**Supporting changes**
- `apply`: implemented the global-attribute add/set path (previously stubbed).
- `loop`/CLI: thread the real filename through `converge()` — the byte round-trip drops it (the codec uses a placeholder), so filename resolvers need it restored on each load.

**Roadmap** (`docs/superpowers/specs/2026-06-20-resolver-fixability-roadmap.md`): classifies all 42 ISTP rules into AUTO / STAGED / DATA / USER and sets the Phase-1b order. `Descriptor`/`Data_type`/`Source_name` (the `ABBREV>description` ones) are deferred to the STAGED slice since the description is human input.

## Test Plan
- [x] `uv run pytest` — 332 passed (10 new)
- [x] `make lint` — clean
- [x] Parser + per-resolver unit tests (incl. non-conventional filename → `None`, no-version token)
- [x] Global-attribute add/set round-trip (with the pycdfpp object-lifetime gotcha pinned)
- [x] End-to-end: convergence fixes a malformed `Logical_file_id` from the filename and clears the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)