### PR TITLE
feat(resolver): fix epoch VAR_TYPE via ISTP-VAR-002 (Phase 1b graph win)

### DIFF
--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -63,7 +63,8 @@ REGISTRY: list[ResolverEntry] = [
         resolver=var_type_infer,
         auto_apply=ApplyPolicy.IF_UNIQUE,
         confidence_default=0.9,
-        triggers=["ISTP-VA-001", "ISTP-VA-004"],
+        # GA/VA-001 (missing), VA-004 (invalid value), VAR-002 (epoch must be support_data)
+        triggers=["ISTP-VA-001", "ISTP-VA-004", "ISTP-VAR-002"],
     ),
     ResolverEntry(
         attribute="DEPEND_0",

--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -63,7 +63,7 @@ REGISTRY: list[ResolverEntry] = [
         resolver=var_type_infer,
         auto_apply=ApplyPolicy.IF_UNIQUE,
         confidence_default=0.9,
-        # GA/VA-001 (missing), VA-004 (invalid value), VAR-002 (epoch must be support_data)
+        # VA-001 (missing), VA-004 (invalid value), VAR-002 (epoch must be support_data)
         triggers=["ISTP-VA-001", "ISTP-VA-004", "ISTP-VAR-002"],
     ),
     ResolverEntry(

--- a/tests/test_resolver_loop.py
+++ b/tests/test_resolver_loop.py
@@ -56,18 +56,25 @@ def test_converge_caps_iterations():
     assert report.stopped_reason in {"converged", "no_progress", "max_iter"}
 
 
-def test_converge_unmodified_file_reports():
+def test_converge_reduces_errors_on_real_file():
+    # The real MMS file has genuine ISTP errors the resolver can fix: a
+    # filename-derived Logical_file_id and the epoch VAR_TYPE (must be
+    # support_data, ISTP-VAR-002). Converging it must reduce the error count.
     with open(_CDF, "rb") as f:
         data = f.read()
     suite = get_suite("ISTP")
     assert suite is not None
-    report, out = converge(data, suite, max_iter=5)
+    loaded = CdfCodec.load(data)
+    assert loaded is not None
+    baseline = suite.run(loaded).count_by_severity()["ERROR"]
+
+    report, out = converge(data, suite, max_iter=5, filename=os.path.basename(_CDF))
+
     assert isinstance(report, ConvergenceReport)
-    assert isinstance(out, bytes)
-    assert report.stopped_reason in {"converged", "no_progress", "max_iter"}
-    # Never auto-overwrite an attribute on a file we were not asked to change:
-    # every auto-applied fix must add a genuinely-missing attribute, not set one.
-    assert all(f.action == "add" for f in report.applied)
+    assert report.remaining_errors < baseline
+    assert any(f.attribute == "VAR_TYPE" and f.value == "support_data" for f in report.applied)
+    fixed = pycdfpp.load(out)
+    assert [x for x in fixed["mms1_asp_epoch"].attributes["VAR_TYPE"]] == ["support_data"]
 
 
 def test_failure_signature_distinguishes_rules_on_same_target():

--- a/tests/test_resolver_loop.py
+++ b/tests/test_resolver_loop.py
@@ -72,7 +72,10 @@ def test_converge_reduces_errors_on_real_file():
 
     assert isinstance(report, ConvergenceReport)
     assert report.remaining_errors < baseline
-    assert any(f.attribute == "VAR_TYPE" and f.value == "support_data" for f in report.applied)
+    assert any(
+        f.variable == "mms1_asp_epoch" and f.attribute == "VAR_TYPE" and f.value == "support_data"
+        for f in report.applied
+    )
     fixed = pycdfpp.load(out)
     assert [x for x in fixed["mms1_asp_epoch"].attributes["VAR_TYPE"]] == ["support_data"]
 

--- a/tests/test_resolver_registry.py
+++ b/tests/test_resolver_registry.py
@@ -36,3 +36,9 @@ def test_registry_has_filename_global_entries():
     attrs = {e.attribute for e in filename_entries}
     assert {"Logical_file_id", "Logical_source", "Data_version"} <= attrs
     assert all(e.scope == Scope.GLOBAL for e in filename_entries)
+
+
+def test_var_type_entry_triggers_on_epoch_rule():
+    var_type = [e for e in REGISTRY if e.attribute == "VAR_TYPE"]
+    triggers = {t for e in var_type for t in e.triggers}
+    assert "ISTP-VAR-002" in triggers  # epoch VAR_TYPE=support_data graph win


### PR DESCRIPTION
## Summary

Wires `ISTP-VAR-002` (EpochAttributes — a time variable's `VAR_TYPE` must be `support_data`) into the existing `VAR_TYPE` graph resolver. `var_type_infer` already infers `support_data` for a variable referenced by a `DEPEND_i` pointer, so this is a one-trigger change that makes the convergence loop repair a very common real-world non-compliance.

**Impact:** combined with the filename-derived globals (#26), converging the unmodified MMS resource CDF now drops it from **5 ERRORs → 2**. The remaining two are the honest floor: `UNITS` (physical → USER, never fabricated) and a `uint8` `FILLVAL`-range case (a later slice — needs unsigned FILLVAL mapping + VA-019 routing).

The old unmodified-file loop test asserted "no auto `set`" (to guard the over-proposal bug). That bug is covered by a dedicated engine test; with VAR-002 wired there are now *legitimate* sets on flagged attributes, so this repurposes the test into a real-file regression: error count drops and the epoch `VAR_TYPE` is corrected.

## Test Plan
- [x] `uv run pytest` — 333 passed
- [x] `make lint` — clean
- [x] Registry test: `VAR_TYPE` entry triggers on `ISTP-VAR-002`
- [x] Real-file regression: converge reduces the MMS error count and sets epoch `VAR_TYPE=support_data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)