### PR TITLE
feat(resolver): staged truncation for over-length descriptive attributes (VA-020/021/022)

### DIFF
--- a/src/astralint/resolver/models.py
+++ b/src/astralint/resolver/models.py
@@ -14,6 +14,7 @@ class ReferenceSource(str, Enum):  # noqa: UP042
     TYPE_RULE = "type_rule"
     GRAPH_RULE = "graph_rule"
     FILENAME = "filename_convention"
+    FORMAT_RULE = "format_rule"  # deterministic reshaping of an existing value (length/format)
     USER = "user"
 
 

--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -6,7 +6,28 @@ from .sources.filename import (
 )
 from .sources.graph_rules import depend0_finder, display_type_infer, var_type_infer
 from .sources.pointers import dangling_pointer_suggestion
+from .sources.text import truncate_to_limit
 from .sources.type_rules import fillval_by_type, fillval_outside_range, scaletyp_default
+
+# Over-length descriptive attributes (ISTP hard limits) -> staged truncation.
+_TRUNCATE_TRIGGERS = {
+    "CATDESC": "ISTP-VA-020",
+    "FIELDNAM": "ISTP-VA-021",
+    "LABLAXIS": "ISTP-VA-022",
+}
+
+
+def _truncate_entry(attribute: str, trigger: str) -> "ResolverEntry":
+    return ResolverEntry(
+        attribute=attribute,
+        scope=Scope.VARIABLE,
+        sources=[ReferenceSource.FORMAT_RULE],
+        resolver=truncate_to_limit,
+        auto_apply=ApplyPolicy.NEVER,  # lossy -> always staged for review
+        confidence_default=0.5,
+        triggers=[trigger],
+    )
+
 
 # Rule references that flag a dangling pointer for each pointer family.
 _POINTER_TRIGGERS = {
@@ -128,4 +149,5 @@ REGISTRY: list[ResolverEntry] = [
         triggers=["ISTP-GA-005", "ISTP-GA-001"],
     ),
     *[_pointer_entry(attr, triggers) for attr, triggers in _POINTER_TRIGGERS.items()],
+    *[_truncate_entry(attr, trigger) for attr, trigger in _TRUNCATE_TRIGGERS.items()],
 ]

--- a/src/astralint/resolver/sources/text.py
+++ b/src/astralint/resolver/sources/text.py
@@ -1,0 +1,28 @@
+from ...base.file import File
+from ...base.validation_result import ValidationResult
+from ..models import ResolverOutput
+
+# ISTP hard length limits per descriptive attribute.
+_MAX_LENGTH = {"CATDESC": 120, "FIELDNAM": 50, "LABLAXIS": 20}
+
+
+def truncate_to_limit(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    """ISTP-VA-020/021/022: an over-long descriptive attribute. Propose the value
+    truncated to the hard limit. Always STAGED — truncation is lossy (it can cut
+    mid-word and drop meaning), so it is a starting point for a human, never an
+    auto-fix."""
+    limit = _MAX_LENGTH.get(attribute)
+    if limit is None or variable is None or variable not in file.variables:
+        return None
+    attr = file.variables[variable].attributes.get(attribute)
+    if attr is None or not attr.values:
+        return None
+    current = attr.values[0]
+    if not isinstance(current, str) or len(current) <= limit:
+        return None
+    return ResolverOutput(
+        value=current[:limit],
+        provenance_note=f"truncated to the {limit}-char limit; review (text was shortened)",
+    )

--- a/tests/test_resolver_engine.py
+++ b/tests/test_resolver_engine.py
@@ -133,3 +133,16 @@ def test_resolve_reads_reference_from_enclosing_rule_group():
     )
     fixes = resolve(_file(), top)
     assert any(f.attribute == "FILLVAL" and f.auto for f in fixes)
+
+
+def test_resolve_over_long_lablaxis_is_staged_truncation():
+    f = _file()
+    f.variables["flux"].attributes["LABLAXIS"] = _attr(
+        "LABLAXIS", "this_label_is_way_too_long_over_twenty"
+    )
+    failures = _group([_failure("ISTP-VA-022", "flux/LABLAXIS")])
+    fixes = resolve(f, failures)
+    lab = [x for x in fixes if x.attribute == "LABLAXIS"]
+    assert len(lab) == 1
+    assert lab[0].auto is False  # staged, never auto-applied
+    assert lab[0].value == "this_label_is_way_too_long_over_twenty"[:20]

--- a/tests/test_resolver_registry.py
+++ b/tests/test_resolver_registry.py
@@ -50,3 +50,13 @@ def test_fillval_entry_triggers_on_fillval_range():
     fillval = [e for e in REGISTRY if e.attribute == "FILLVAL"]
     triggers = {t for e in fillval for t in e.triggers}
     assert "ISTP-VA-019" in triggers  # FillvalOutsideRange -> set type-standard fill
+
+
+def test_truncation_entries_are_staged():
+    from astralint.resolver.models import ApplyPolicy
+
+    truncate = {
+        e.attribute: e for e in REGISTRY if e.attribute in {"CATDESC", "FIELDNAM", "LABLAXIS"}
+    }
+    assert {"CATDESC", "FIELDNAM", "LABLAXIS"} <= set(truncate)
+    assert all(e.auto_apply == ApplyPolicy.NEVER for e in truncate.values())

--- a/tests/test_resolver_text.py
+++ b/tests/test_resolver_text.py
@@ -1,0 +1,47 @@
+from astralint.base.file import Attribute, DataType, File, Variable
+from astralint.resolver.sources.text import truncate_to_limit
+
+
+def _file(attr_name: str, value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="t.cdf",
+        compression="NONE",
+        attributes={},
+        variables={
+            "v": Variable(
+                name="v",
+                shape=[1],
+                compression="NONE",
+                data_type=DataType.FLOAT32,
+                record_variance=True,
+                attributes={
+                    attr_name: Attribute(
+                        name=attr_name, data_type=[DataType.CHAR], shape=[1], values=[value]
+                    )
+                },
+            )
+        },
+    )
+
+
+def test_truncate_lablaxis_over_20():
+    long = "this_label_is_definitely_over_twenty_chars"
+    out = truncate_to_limit(_file("LABLAXIS", long), "v", "LABLAXIS", None)
+    assert out is not None
+    assert out.value == long[:20]
+    assert len(out.value) == 20
+
+
+def test_truncate_catdesc_over_120():
+    long = "x" * 200
+    out = truncate_to_limit(_file("CATDESC", long), "v", "CATDESC", None)
+    assert out is not None and len(out.value) == 120
+
+
+def test_truncate_none_when_within_limit():
+    assert truncate_to_limit(_file("FIELDNAM", "short_name"), "v", "FIELDNAM", None) is None
+
+
+def test_truncate_none_for_unmanaged_attribute():
+    assert truncate_to_limit(_file("CATDESC", "x" * 200), "v", "UNITS", None) is None


### PR DESCRIPTION
## Summary

The second-biggest real-world error class after FILLVAL-range: over-length descriptive attributes (`ISTP-VA-020` CATDESC>120, `ISTP-VA-021` FIELDNAM>50, `ISTP-VA-022` LABLAXIS>20) — **89 of 325 errors** on a THEMIS ESA file.

Adds a `truncate_to_limit` resolver that proposes the value cut to the hard limit, **always STAGED** (`auto_apply=NEVER`). Truncation is lossy (it can cut mid-word and drop meaning), so it's a reviewed starting point, never an auto-fix.

Also adds a `FORMAT_RULE` `ReferenceSource` for deterministic value-reshaping (reusable for date reformatting later).

**Impact:** on the THEMIS `tha_l2_esa` file the resolver now proposes a disposition for **310 of 325 errors** (221 auto FILLVAL + 89 staged truncations); the remaining ~15 are the genuine USER floor (UNITS, descriptive text needing real input).

## Test Plan
- [x] `uv run pytest` — 347 passed
- [x] `make lint` — clean
- [x] Unit: truncates over-limit (LABLAXIS/CATDESC/FIELDNAM); `None` when within limit or for unmanaged attrs
- [x] Registry: the three truncation entries are `NEVER` (staged)
- [x] Engine: an over-long LABLAXIS routes to a staged truncation fix (`auto is False`, value cut to 20)
- [x] Cross-mission dry run: 89 staged truncations on the THEMIS file (53 FIELDNAM + 30 LABLAXIS + 6 CATDESC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)