### PR TITLE
feat(cli): show an 'astralint fix' hint after lint

### DIFF
--- a/src/astralint/astralint.py
+++ b/src/astralint/astralint.py
@@ -8,6 +8,7 @@ from rich.pretty import Pretty
 
 from .base import (
     ConformanceSuite,
+    File,
     Severity,
     ValidationResultGroup,
     get_suite,
@@ -24,7 +25,7 @@ from .config import (
 from .config.loader import generate_starter_config
 from .config.paths import expand_lint_paths
 from .reports import report
-from .resolver import Fix, converge
+from .resolver import Fix, converge, resolve
 
 app = App()
 config_app = App(name="config", help="Manage AstraLint configuration.")
@@ -119,6 +120,33 @@ def init(force: bool = False):
     console.print("\nEdit this file to customize AstraLint behavior.")
 
 
+def _fix_hint(loaded: list[tuple[Path, File, ValidationResultGroup]]) -> str | None:
+    """Summarise how many findings `astralint fix` can address, across CDF files.
+
+    Counts the resolver's proposed fixes (auto vs staged) without applying
+    anything. Returns None when there is nothing to offer.
+    """
+    auto = staged = 0
+    for _path, file, result in loaded:
+        if file.extension != "cdf":  # the fix command operates on CDF only
+            continue
+        for fix in resolve(file, result.failures_only()):
+            if fix.auto:
+                auto += 1
+            else:
+                staged += 1
+    if not (auto or staged):
+        return None
+    cdf_paths = [p for p, file, _ in loaded if file.extension == "cdf"]
+    target = str(cdf_paths[0]) if len(cdf_paths) == 1 else "<file>"
+    parts = []
+    if auto:
+        parts.append(f"{auto} auto-fixable")
+    if staged:
+        parts.append(f"{staged} need review")
+    return f"{', '.join(parts)} — run: astralint fix {target}"
+
+
 @app.command()
 def lint(
     path: list[Path],
@@ -208,17 +236,18 @@ def lint(
     # Run linting
     checker: ConformanceSuite | None = get_suite(cfg.suite)
     if checker:
+        loaded: list[tuple[Path, File, ValidationResultGroup]] = []
         results = []
         for p in files_to_lint:
             if file := load_file(str(p)):
-                results.append(
-                    checker.run(
-                        file,
-                        select=cfg.select or None,
-                        ignore=cfg.ignore or None,
-                        severity_overrides=cfg.severity_overrides or None,
-                    )
+                file_result = checker.run(
+                    file,
+                    select=cfg.select or None,
+                    ignore=cfg.ignore or None,
+                    severity_overrides=cfg.severity_overrides or None,
                 )
+                loaded.append((p, file, file_result))
+                results.append(file_result)
 
         results = ValidationResultGroup(
             name="AstraLint Results", rule_reference="", results=results, severity=Severity.INFO
@@ -230,6 +259,12 @@ def lint(
             show_passed=cfg.output.show_passed,
             failed_only=failed_only,
         )
+
+        # Point the user at `astralint fix` when it can help (console output only).
+        if cfg.output.format == "console" and not cfg.output.dest:
+            hint = _fix_hint(loaded)
+            if hint:
+                console.print(f"\n[cyan]→[/] {escape(hint)}")
 
         # Exit with error code if validation failed
         if results.has_errors():

--- a/tests/test_resolver_cli.py
+++ b/tests/test_resolver_cli.py
@@ -51,3 +51,45 @@ def test_fix_line_escapes_file_derived_markup():
     assert "x\\[red]y" in line  # target_path tag-like bracket escaped
     assert "\\[bad]" in line  # value bracket escaped
     assert "see \\[zap]" in line  # provenance bracket escaped
+
+
+def test_fix_hint_reports_auto_fixes():
+    from astralint.astralint import _fix_hint
+    from astralint.base import get_suite, load_file
+
+    p = Path(_CDF)
+    file = load_file(str(p))
+    suite = get_suite("ISTP")
+    assert file is not None and suite is not None
+    hint = _fix_hint([(p, file, suite.run(file))])
+    assert hint is not None
+    assert "auto-fixable" in hint
+    assert "astralint fix" in hint
+
+
+def test_fix_hint_none_when_nothing_to_fix():
+    from astralint.astralint import _fix_hint
+
+    assert _fix_hint([]) is None
+
+
+def test_fix_hint_skips_non_cdf_files():
+    from astralint.astralint import _fix_hint
+    from astralint.base import get_suite, load_file
+
+    p = Path(_CDF)
+    file = load_file(str(p))
+    suite = get_suite("ISTP")
+    assert file is not None and suite is not None
+    non_cdf = file.model_copy(update={"extension": "fits"})
+    assert _fix_hint([(p, non_cdf, suite.run(file))]) is None
+
+
+def test_lint_prints_fix_hint(capsys):
+    import pytest
+
+    from astralint.astralint import lint
+
+    with pytest.raises(SystemExit):  # the resource file has errors -> exit 1
+        lint([Path(_CDF)], suite="ISTP")
+    assert "astralint fix" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Closes the loop on the originally-requested UX: after the `astralint lint` verdict (console output only), surface how many findings the resolver can address and point at the fix command:

```
✗ Found 8 problems (5 errors, 3 warnings), plus 13 info findings

→ 2 auto-fixable — run: astralint fix mms1_asp2_srvy_l1b_stat_00000000_v01.cdf
```

- Counts come from a **read-only** `resolve()` over the linted CDF files (no mutation), so the hint is **honest** and reflects whatever resolvers exist — e.g. THEMIS `tha_l2_esa` shows `221 auto-fixable` today, and will add `89 need review` once the truncation PR (#29) lands, with no change here.
- Only shown when there's something to offer, console output only (not for `--output html/json` or a file `dest`), and only for CDF files (the `fix` command is CDF-only).
- Deferred from the start of Phase 1b precisely so it wouldn't light up on almost nothing — now coverage is broad enough to make it worthwhile.

## Test Plan
- [x] `uv run pytest` — 345 passed
- [x] `make lint` — clean
- [x] `_fix_hint` reports auto-fix counts on the resource CDF; returns `None` for nothing-to-fix and for non-CDF files
- [x] `lint` end-to-end prints the hint (capsys)
- [x] Manual: real files (MMS → "2 auto-fixable", THEMIS → "221 auto-fixable")

🤖 Generated with [Claude Code](https://claude.com/claude-code)