### PR TITLE
fix(codec): tolerate an unknown CDF compression type on load

### DIFF
--- a/src/astralint/codecs/cdf.py
+++ b/src/astralint/codecs/cdf.py
@@ -41,6 +41,19 @@ def _to_data_type(cdf_dtype: CDFDataType) -> DataType:
     return type_mapping.get(cdf_dtype, DataType.NONE)
 
 
+def _compression_name(item) -> str:
+    """The compression type name, tolerating an unknown CompressionType code.
+
+    pycdfpp raises ``ValueError`` when ``.compression`` carries a code its enum
+    doesn't know (malformed or newer-than-our-pycdfpp file); a single bad field
+    shouldn't abort the whole load — fall back to a placeholder.
+    """
+    try:
+        return item.compression.name
+    except ValueError:
+        return "UNKNOWN"
+
+
 @singledispatch
 def _parse_attribute(attr) -> Attribute:
     raise NotImplementedError(f"Unsupported attribute type: {type(attr)}")
@@ -73,7 +86,7 @@ def _parse_variable(var: CDFVariable) -> Variable:
         name=var.name,
         shape=list(var.shape),
         attributes={name: _parse_attribute(attr) for name, attr in var.attributes.items()},
-        compression=var.compression.name,
+        compression=_compression_name(var),
         record_variance=not var.is_nrv,
         data_type=_to_data_type(var.type),
     )
@@ -99,7 +112,7 @@ class CdfCodec(Codec):
             return File(
                 extension="cdf",
                 filename=fname,
-                compression=cdf.compression.name,
+                compression=_compression_name(cdf),
                 attributes={name: _parse_attribute(attr) for name, attr in cdf.attributes.items()},
                 variables={name: _parse_variable(var) for name, var in cdf.items()},
             )

--- a/tests/test_cdf_codec_robustness.py
+++ b/tests/test_cdf_codec_robustness.py
@@ -1,0 +1,30 @@
+class _Comp:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _Item:
+    """Stand-in for a pycdfpp CDF/Variable whose .compression may raise on an
+    unknown CompressionType code (as a malformed/newer file produces)."""
+
+    def __init__(self, comp):
+        self._comp = comp
+
+    @property
+    def compression(self):
+        if isinstance(self._comp, Exception):
+            raise self._comp
+        return self._comp
+
+
+def test_compression_name_returns_known_name():
+    from astralint.codecs.cdf import _compression_name
+
+    assert _compression_name(_Item(_Comp("gzip"))) == "gzip"
+
+
+def test_compression_name_handles_unknown_enum():
+    from astralint.codecs.cdf import _compression_name
+
+    bad = _Item(ValueError("312 is not a valid CompressionType"))
+    assert _compression_name(bad) == "UNKNOWN"


### PR DESCRIPTION
## Summary

A cross-mission scan of ~90 real CDFs surfaced a codec robustness gap: pycdfpp raises `ValueError: <N> is not a valid CompressionType` when a variable (or the file) carries a compression code its enum doesn't know — malformed, or written by a newer CDF library. The codec accessed `.compression.name` directly, so one bad field **aborted the entire load** (e.g. `broken_cdf.cdf` crashed even though pycdfpp parsed it fine).

Wraps compression-name access in `_compression_name`, falling back to `"UNKNOWN"` so the file still loads and can be validated.

## Test Plan
- [x] Reproducer tests (fail before, pass after): `_compression_name` returns the known name, and falls back to `"UNKNOWN"` on an unknown-enum `ValueError`
- [x] `uv run pytest` — 353 passed
- [x] `make lint` — clean
- [x] Manual: the previously-crashing `broken_cdf.cdf` now loads (`compression: UNKNOWN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)