### PR TITLE
feat(resolver): reformat Generation_date to ISTP yyyymmdd (GA-015)

### DIFF
--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -6,7 +6,7 @@ from .sources.filename import (
 )
 from .sources.graph_rules import depend0_finder, display_type_infer, var_type_infer
 from .sources.pointers import dangling_pointer_suggestion
-from .sources.text import truncate_to_limit
+from .sources.text import generation_date_format, truncate_to_limit
 from .sources.type_rules import fillval_by_type, fillval_outside_range, scaletyp_default
 
 # Over-length descriptive attributes (ISTP hard limits) -> staged truncation.
@@ -147,6 +147,17 @@ REGISTRY: list[ResolverEntry] = [
         auto_apply=ApplyPolicy.ALWAYS,
         confidence_default=0.9,
         triggers=["ISTP-GA-005", "ISTP-GA-001"],
+    ),
+    ResolverEntry(
+        # GA-015: Generation_date not yyyymmdd. Lossless reformat of an existing
+        # parseable date (no fabrication of a missing one).
+        attribute="Generation_date",
+        scope=Scope.GLOBAL,
+        sources=[ReferenceSource.FORMAT_RULE],
+        resolver=generation_date_format,
+        auto_apply=ApplyPolicy.ALWAYS,
+        confidence_default=0.9,
+        triggers=["ISTP-GA-015"],
     ),
     *[_pointer_entry(attr, triggers) for attr, triggers in _POINTER_TRIGGERS.items()],
     *[_truncate_entry(attr, trigger) for attr, trigger in _TRUNCATE_TRIGGERS.items()],

--- a/src/astralint/resolver/sources/text.py
+++ b/src/astralint/resolver/sources/text.py
@@ -1,9 +1,45 @@
+from datetime import datetime
+
 from ...base.file import File
 from ...base.validation_result import ValidationResult
 from ..models import ResolverOutput
 
 # ISTP hard length limits per descriptive attribute.
 _MAX_LENGTH = {"CATDESC": 120, "FIELDNAM": 50, "LABLAXIS": 20}
+
+# Common date formats a Generation_date might use instead of the ISTP yyyymmdd.
+_DATE_FORMATS = ("%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y", "%d/%m/%Y", "%Y-%m-%dT%H:%M:%S")
+
+
+def _parse_date(raw: str) -> datetime | None:
+    text = raw.strip()
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(text)  # assorted ISO-8601 variants
+    except ValueError:
+        return None
+
+
+def generation_date_format(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    """ISTP-GA-015: Generation_date must be yyyymmdd. Reformat a present, parseable
+    date losslessly (same date, ISTP format). Returns None when it is absent or
+    not parseable (no fabrication)."""
+    attr = file.attributes.get("Generation_date")
+    if attr is None or not attr.values or not isinstance(attr.values[0], str):
+        return None
+    parsed = _parse_date(attr.values[0])
+    if parsed is None:
+        return None
+    return ResolverOutput(
+        value=parsed.strftime("%Y%m%d"),
+        provenance_note="reformatted Generation_date to the ISTP yyyymmdd format",
+    )
 
 
 def truncate_to_limit(

--- a/tests/test_resolver_text.py
+++ b/tests/test_resolver_text.py
@@ -45,3 +45,52 @@ def test_truncate_none_when_within_limit():
 
 def test_truncate_none_for_unmanaged_attribute():
     assert truncate_to_limit(_file("CATDESC", "x" * 200), "v", "UNITS", None) is None
+
+
+def _file_with_gen_date(value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="t.cdf",
+        compression="NONE",
+        variables={},
+        attributes={
+            "Generation_date": Attribute(
+                name="Generation_date", data_type=[DataType.CHAR], shape=[1], values=[value]
+            )
+        },
+    )
+
+
+def test_generation_date_reformats_iso():
+    from astralint.resolver.sources.text import generation_date_format
+
+    out = generation_date_format(_file_with_gen_date("2022-02-21"), None, "Generation_date", None)
+    assert out is not None
+    assert out.value == "20220221"
+
+
+def test_generation_date_reformats_with_time():
+    from astralint.resolver.sources.text import generation_date_format
+
+    out = generation_date_format(
+        _file_with_gen_date("2022-02-21T13:45:00"), None, "Generation_date", None
+    )
+    assert out is not None and out.value == "20220221"
+
+
+def test_generation_date_none_when_unparseable():
+    from astralint.resolver.sources.text import generation_date_format
+
+    assert (
+        generation_date_format(
+            _file_with_gen_date("sometime in Feb"), None, "Generation_date", None
+        )
+        is None
+    )
+
+
+def test_generation_date_none_when_absent():
+    from astralint.resolver.sources.text import generation_date_format
+
+    f = File(extension="cdf", filename="t.cdf", compression="NONE", variables={}, attributes={})
+    assert generation_date_format(f, None, "Generation_date", None) is None


### PR DESCRIPTION
## Summary

`ISTP-GA-015` requires `Generation_date` in `yyyymmdd`; real files often carry an ISO-ish date instead (e.g. `2022-02-21` — seen on the Solar Orbiter file in the original lint). `generation_date_format` parses a present, parseable date and reformats it **losslessly** to `yyyymmdd` (AUTO — same date, just the ISTP format). Returns `None` when the attribute is absent or unparseable — no fabrication of a missing generation date.

Reuses the `FORMAT_RULE` source added with the truncation slice.

## Test Plan
- [x] `uv run pytest` — 355 passed
- [x] `make lint` — clean
- [x] Reformats ISO dates (with/without time); `None` for unparseable or absent
- [x] End-to-end: a `2022-02-21` Generation_date routes to a `20220221` auto fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)