### PR TITLE
docs: document the resolver component in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ make build              # uv build
 uv run pytest tests/test_assertions.py          # run a single test file
 uv run pytest tests/test_assertions.py -k name  # run a single test by name
 uv run astralint lint myfile.cdf                # run the CLI
+uv run astralint fix myfile.cdf --apply none    # dry-run the auto-fixer
 ```
 
 ## Architecture
@@ -38,6 +39,8 @@ uv run astralint lint myfile.cdf                # run the CLI
 
 7. **Reports** (`src/astralint/reports/`): Rich console output and Jinja2-based HTML reports.
 
+8. **Resolver** (`src/astralint/resolver/`): Turns validation failures into proposed fixes. A declarative `registry.py` (`ResolverEntry` list) maps `(attribute, scope)` + rule-reference triggers to resolver functions in `sources/` (`type_rules`, `graph_rules`, `pointers`, `filename`, `text`). `engine.resolve(file, failures)` walks failing leaves and emits deduped `Fix`es (auto vs staged); `apply.py` mutates a CDF via pycdfpp; `loop.converge()` runs validate→fix→re-validate to a corrected file. Drives the `astralint fix` command and the post-`lint` hint. Numeric/physical and identity/provenance attributes are never fabricated.
+
 ## Code Style
 
 - Line length: 100
@@ -53,3 +56,4 @@ uv run astralint lint myfile.cdf                # run the CLI
 - **New assertion**: extend `BaseAssertion` in `src/astralint/base/yaml_rules/assertions/`
 - **New suite**: add directory in `src/astralint/suites/` with `suite.yaml` + `rules/`
 - **New report format**: add reporter in `src/astralint/reports/`
+- **New auto-fix**: add a resolver function in `src/astralint/resolver/sources/` and a `ResolverEntry` in `resolver/registry.py` (triggered by the rule's reference)


### PR DESCRIPTION
## Summary

The project `CLAUDE.md` listed 7 architecture components but predated the resolver subsystem. Adds:
- the **Resolver** as architecture component 8 (registry / engine / apply / loop + `sources/`),
- the `astralint fix --apply none` dry-run to the Commands list,
- a "New auto-fix" entry under Extensibility.

Docs-only; keeps the contributor guide in sync with the merged resolver work.

## Test Plan
- [x] `make lint` (codespell) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)