### PR TITLE
feat(resolver): unsigned-integer FILLVAL defaults (UINT8/16/32)

### DIFF
--- a/src/astralint/resolver/sources/type_rules.py
+++ b/src/astralint/resolver/sources/type_rules.py
@@ -4,13 +4,16 @@ from ...base.file import DataType, File
 from ...base.validation_result import ValidationResult
 from ..models import ResolverOutput
 
-# ISTP default fill values keyed on the abstract CDF data type. Unsigned types
-# are intentionally omitted in Phase 1 (no agreed ISTP default here yet).
+# ISTP/CDAWeb default fill values keyed on the abstract CDF data type. Unsigned
+# integers use the maximum value (all bits set), the conventional unsigned fill.
 _FILLVAL_BY_TYPE: dict[DataType, Any] = {
     DataType.INT8: -128,
     DataType.INT16: -32768,
     DataType.INT32: -(2**31),
     DataType.INT64: -(2**63),
+    DataType.UINT8: 2**8 - 1,
+    DataType.UINT16: 2**16 - 1,
+    DataType.UINT32: 2**32 - 1,
     DataType.TT2000: -(2**63),
     DataType.FLOAT32: -1e31,
     DataType.FLOAT64: -1e31,

--- a/tests/test_resolver_type_rules.py
+++ b/tests/test_resolver_type_rules.py
@@ -39,9 +39,20 @@ def test_fillval_char_is_blank():
     assert out.value == " "
 
 
+def test_fillval_unsigned_is_max_value():
+    # CDAWeb convention: unsigned fill is the maximum value (all bits set).
+    for data_type, expected in (
+        (DataType.UINT8, 255),
+        (DataType.UINT16, 65535),
+        (DataType.UINT32, 4294967295),
+    ):
+        out = fillval_by_type(_var(data_type), "v", "FILLVAL", None)
+        assert out is not None
+        assert out.value == expected
+
+
 def test_fillval_unmapped_type_returns_none():
-    # Unsigned types are intentionally unmapped in Phase 1.
-    assert fillval_by_type(_var(DataType.UINT32), "v", "FILLVAL", None) is None
+    assert fillval_by_type(_var(DataType.NONE), "v", "FILLVAL", None) is None
 
 
 def test_fillval_unknown_variable_returns_none():
@@ -116,3 +127,25 @@ def test_fillval_outside_range_none_without_validminmax():
         },
     )
     assert fillval_outside_range(f, "v", "FILLVAL", None) is None
+
+
+def test_fillval_outside_range_unsigned_proposes_max():
+    from astralint.resolver.sources.type_rules import fillval_outside_range
+
+    # UINT8 var with range [0, 100] and an in-range FILLVAL: 255 (max) is outside.
+    out = fillval_outside_range(
+        _var_with_range(0, 100, 50, dt=DataType.UINT8), "v", "FILLVAL", None
+    )
+    assert out is not None
+    assert out.value == 255
+
+
+def test_fillval_outside_range_unsigned_none_when_full_range():
+    from astralint.resolver.sources.type_rules import fillval_outside_range
+
+    # A UINT8 var whose valid range spans the whole type [0, 255] has no possible
+    # out-of-range fill — the resolver must not propose one.
+    assert (
+        fillval_outside_range(_var_with_range(0, 255, 255, dt=DataType.UINT8), "v", "FILLVAL", None)
+        is None
+    )


### PR DESCRIPTION
## Summary

Adds the CDAWeb convention for unsigned fill values — the maximum value (all bits set): `UINT8=255`, `UINT16=65535`, `UINT32=4294967295`. Previously `_FILLVAL_BY_TYPE` omitted unsigned types.

Effect:
- a **missing** FILLVAL on an unsigned variable (`ISTP-VA-001`) now gets the default, and
- an **in-range** unsigned FILLVAL (`ISTP-VA-019`) is reset to the max when that is actually outside the variable's `[VALIDMIN, VALIDMAX]`.

**Honest edge case:** when a variable's valid range spans the whole type (e.g. `UINT8` with `VALIDMIN=0, VALIDMAX=255` — exactly the `mms1_asp_stat` case in the test resource), there is *no* possible out-of-range fill, and `fillval_outside_range` correctly proposes nothing. That's a genuine data-modeling issue in the file, not something the resolver should fabricate around.

## Test Plan
- [x] `uv run pytest` — 360 passed
- [x] `make lint` — clean
- [x] `fillval_by_type` returns 255 / 65535 / 4294967295 for UINT8/16/32
- [x] `fillval_outside_range` proposes 255 for a UINT8 var with range `[0,100]`; returns `None` when the range is the full `[0,255]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)