### PR TITLE
feat(resolver): flag irreducible attributes as "needs your input" (USER disposition)

### DIFF
--- a/src/astralint/astralint.py
+++ b/src/astralint/astralint.py
@@ -121,29 +121,23 @@ def init(force: bool = False):
 
 
 def _fix_hint(loaded: list[tuple[Path, File, ValidationResultGroup]]) -> str | None:
-    """Summarise how many findings `astralint fix` can address, across CDF files.
+    """Summarise how the resolver can address findings, across CDF files.
 
-    Counts the resolver's proposed fixes (auto vs staged) without applying
+    Counts proposed fixes by disposition (auto / staged / user) without applying
     anything. Returns None when there is nothing to offer.
     """
-    auto = staged = 0
+    counts = {"auto": 0, "staged": 0, "user": 0}
     for _path, file, result in loaded:
         if file.extension != "cdf":  # the fix command operates on CDF only
             continue
         for fix in resolve(file, result.failures_only()):
-            if fix.auto:
-                auto += 1
-            else:
-                staged += 1
-    if not (auto or staged):
+            counts[fix.disposition] += 1
+    if not any(counts.values()):
         return None
     cdf_paths = [p for p, file, _ in loaded if file.extension == "cdf"]
     target = str(cdf_paths[0]) if len(cdf_paths) == 1 else "<file>"
-    parts = []
-    if auto:
-        parts.append(f"{auto} auto-fixable")
-    if staged:
-        parts.append(f"{staged} need review")
+    labels = (("auto", "auto-fixable"), ("staged", "need review"), ("user", "need your input"))
+    parts = [f"{counts[key]} {label}" for key, label in labels if counts[key]]
     return f"{', '.join(parts)} — run: astralint fix {target}"
 
 
@@ -298,6 +292,12 @@ def _fix_line(fx: Fix, *, staged: bool) -> str:
     )
 
 
+def _user_line(fx: Fix) -> str:
+    """Render a value-less 'needs your input' fix (no value to show)."""
+    target = escape(fx.target_path)
+    return f"  [magenta]{escape(fx.attribute)}[/] {target} [dim]— {escape(fx.provenance_note)}[/]"
+
+
 @app.command()
 def fix(
     path: Path,
@@ -343,10 +343,16 @@ def fix(
     else:
         console.print("No auto-applicable fixes found.")
 
-    if convergence.staged:
-        console.print(f"\n[bold]Staged suggestions ({len(convergence.staged)}) — need review:[/]")
-        for fx in convergence.staged:
+    review = [fx for fx in convergence.staged if fx.disposition == "staged"]
+    needs_input = [fx for fx in convergence.staged if fx.disposition == "user"]
+    if review:
+        console.print(f"\n[bold]Staged suggestions ({len(review)}) — need review:[/]")
+        for fx in review:
             console.print(_fix_line(fx, staged=True))
+    if needs_input:
+        console.print(f"\n[bold]Need your input ({len(needs_input)}) — cannot be auto-filled:[/]")
+        for fx in needs_input:
+            console.print(_user_line(fx))
 
     console.print(
         f"\n[dim]iterations={convergence.iterations} stopped={convergence.stopped_reason} "

--- a/src/astralint/resolver/models.py
+++ b/src/astralint/resolver/models.py
@@ -63,3 +63,13 @@ class Fix(BaseModel):
     confidence: float
     provenance_note: str
     auto: bool  # decided by the engine: always | (if_unique & not ambiguous)
+
+    @property
+    def disposition(self) -> str:
+        """How the fix is offered: applied automatically, suggested for review,
+        or flagged as requiring human input (a value-less USER fix)."""
+        if self.auto:
+            return "auto"
+        if self.source == ReferenceSource.USER:
+            return "user"
+        return "staged"

--- a/src/astralint/resolver/registry.py
+++ b/src/astralint/resolver/registry.py
@@ -8,6 +8,43 @@ from .sources.graph_rules import depend0_finder, display_type_infer, var_type_in
 from .sources.pointers import dangling_pointer_suggestion
 from .sources.text import generation_date_format, truncate_to_limit
 from .sources.type_rules import fillval_by_type, fillval_outside_range, scaletyp_default
+from .sources.user import needs_user_input
+
+# Irreducible attributes — physical, provenance/identity, prose, external IDs —
+# flagged as "needs your input" (never fabricated). attribute -> rule triggers.
+_USER_GLOBAL = {
+    # Mandatory (GA-001) provenance / prose / description.
+    "PI_name": ["ISTP-GA-001"],
+    "PI_affiliation": ["ISTP-GA-001"],
+    "TEXT": ["ISTP-GA-001", "ISTP-GA-011"],
+    "Logical_source_description": ["ISTP-GA-001"],
+    "Descriptor": ["ISTP-GA-001", "ISTP-GA-008"],
+    "Data_type": ["ISTP-GA-001", "ISTP-GA-006"],
+    "Source_name": ["ISTP-GA-001", "ISTP-GA-007"],
+    # Recommended (GA-002) provenance / prose / external identifiers, plus their
+    # own value/format rules. (Time_resolution is excluded — it is data-derived.)
+    "DOI": ["ISTP-GA-002", "ISTP-GA-014"],
+    "spase_DatasetResourceID": ["ISTP-GA-002"],
+    "Acknowledgement": ["ISTP-GA-002"],
+    "Rules_of_use": ["ISTP-GA-002"],
+    "Generated_by": ["ISTP-GA-002"],
+    "Project": ["ISTP-GA-002", "ISTP-GA-012"],
+    "Discipline": ["ISTP-GA-002", "ISTP-GA-009"],
+}
+_USER_VARIABLE = {"UNITS": ["ISTP-VA-009"]}
+
+
+def _user_entry(attribute: str, scope: Scope, triggers: list[str]) -> "ResolverEntry":
+    return ResolverEntry(
+        attribute=attribute,
+        scope=scope,
+        sources=[ReferenceSource.USER],
+        resolver=needs_user_input,
+        auto_apply=ApplyPolicy.NEVER,  # value-less: always surfaced, never applied
+        confidence_default=0.0,
+        triggers=triggers,
+    )
+
 
 # Over-length descriptive attributes (ISTP hard limits) -> staged truncation.
 _TRUNCATE_TRIGGERS = {
@@ -161,4 +198,6 @@ REGISTRY: list[ResolverEntry] = [
     ),
     *[_pointer_entry(attr, triggers) for attr, triggers in _POINTER_TRIGGERS.items()],
     *[_truncate_entry(attr, trigger) for attr, trigger in _TRUNCATE_TRIGGERS.items()],
+    *[_user_entry(attr, Scope.GLOBAL, triggers) for attr, triggers in _USER_GLOBAL.items()],
+    *[_user_entry(attr, Scope.VARIABLE, triggers) for attr, triggers in _USER_VARIABLE.items()],
 ]

--- a/src/astralint/resolver/sources/user.py
+++ b/src/astralint/resolver/sources/user.py
@@ -1,0 +1,15 @@
+from ...base.file import File
+from ...base.validation_result import ValidationResult
+from ..models import ResolverOutput
+
+
+def needs_user_input(
+    file: File, variable: str | None, attribute: str, failure: ValidationResult | None
+) -> ResolverOutput | None:
+    """Flag an irreducible attribute — physical units, identity/provenance, prose,
+    or an external identifier — as requiring human input. Carries no value: these
+    are never auto-filled, only surfaced so nothing is silently unaddressable."""
+    return ResolverOutput(
+        value=None,
+        provenance_note=f"{attribute} must be provided by a human (never auto-filled)",
+    )

--- a/tests/test_resolver_cli.py
+++ b/tests/test_resolver_cli.py
@@ -93,3 +93,17 @@ def test_lint_prints_fix_hint(capsys):
     with pytest.raises(SystemExit):  # the resource file has errors -> exit 1
         lint([Path(_CDF)], suite="ISTP")
     assert "astralint fix" in capsys.readouterr().out
+
+
+def test_fix_hint_counts_user_disposition():
+    from astralint.astralint import _fix_hint
+    from astralint.base import get_suite, load_file
+
+    p = Path(_CDF)
+    file = load_file(str(p))
+    suite = get_suite("ISTP")
+    assert file is not None and suite is not None
+    # construct a file missing a recommended provenance global so a USER fix fires
+    file.attributes.pop("DOI", None)
+    hint = _fix_hint([(p, file, suite.run(file))])
+    assert hint is not None

--- a/tests/test_resolver_registry.py
+++ b/tests/test_resolver_registry.py
@@ -60,3 +60,12 @@ def test_truncation_entries_are_staged():
     }
     assert {"CATDESC", "FIELDNAM", "LABLAXIS"} <= set(truncate)
     assert all(e.auto_apply == ApplyPolicy.NEVER for e in truncate.values())
+
+
+def test_user_entries_are_flagging_only():
+    from astralint.resolver.models import ApplyPolicy, ReferenceSource
+
+    user = [e for e in REGISTRY if ReferenceSource.USER in e.sources]
+    attrs = {e.attribute for e in user}
+    assert {"UNITS", "DOI", "PI_name", "TEXT"} <= attrs
+    assert all(e.auto_apply == ApplyPolicy.NEVER for e in user)

--- a/tests/test_resolver_user.py
+++ b/tests/test_resolver_user.py
@@ -1,0 +1,43 @@
+from astralint.base.file import Attribute, DataType, File
+from astralint.resolver.models import Fix, ReferenceSource, Scope
+from astralint.resolver.sources.user import needs_user_input
+
+
+def _global(attr_name: str) -> File:
+    return File(
+        extension="cdf",
+        filename="t.cdf",
+        compression="NONE",
+        variables={},
+        attributes={
+            attr_name: Attribute(name=attr_name, data_type=[DataType.CHAR], shape=[1], values=[""])
+        },
+    )
+
+
+def test_needs_user_input_flags_without_value():
+    out = needs_user_input(_global("DOI"), None, "DOI", None)
+    assert out is not None
+    assert out.value is None
+    assert "DOI" in out.provenance_note
+
+
+def _fix(source: ReferenceSource, *, auto: bool, value) -> Fix:
+    return Fix(
+        target_path="attributes/X",
+        variable=None,
+        attribute="X",
+        scope=Scope.GLOBAL,
+        action="add",
+        value=value,
+        source=source,
+        confidence=0.0,
+        provenance_note="n",
+        auto=auto,
+    )
+
+
+def test_fix_disposition():
+    assert _fix(ReferenceSource.TYPE_RULE, auto=True, value=1).disposition == "auto"
+    assert _fix(ReferenceSource.FORMAT_RULE, auto=False, value="x").disposition == "staged"
+    assert _fix(ReferenceSource.USER, auto=False, value=None).disposition == "user"


### PR DESCRIPTION
## Summary

Completes the disposition story — every error now resolves to one of **auto / staged / user**. A value-less **USER** fix flags attributes that must come from a human and are never fabricated:

- physical: `UNITS`
- identity/provenance: `PI_name`, `PI_affiliation`, `Source_name`, `Project`
- prose: `TEXT`, `Acknowledgement`, `Rules_of_use`, `Logical_source_description`, `Generated_by`
- external IDs: `DOI`, `spase_DatasetResourceID`
- controlled vocab: `Discipline`, plus `Descriptor`/`Data_type` (the `ABBREV>description` part is human)

keyed to the mandatory (GA-001) and recommended (GA-002) global rules and their own value/format rules.

**Changes:**
- `Fix.disposition` property (`auto` | `staged` | `user`).
- `sources/user.py`: `needs_user_input` resolver (`value=None`, `auto_apply=NEVER`).
- CLI: the post-lint hint now shows a third count (`K need your input`), and `astralint fix` lists a **Need your input** group separately from staged suggestions.

`Time_resolution` is intentionally excluded (it is data-derived, a future DATA-tier resolver).

**Real-file output** (Solar Orbiter `solo_l2_rpw-lfr-surv-swf-b`):
```
→ 2 auto-fixable, 1 need review, 2 need your input — run: astralint fix <file>
...
Need your input (2) — cannot be auto-filled:
  DOI attributes/DOI — DOI must be provided by a human (never auto-filled)
  spase_DatasetResourceID attributes/spase_DatasetResourceID — …
```

## Test Plan
- [x] `uv run pytest` — 364 passed
- [x] `make lint` — clean
- [x] `needs_user_input` returns a value-less flag; `Fix.disposition` maps auto/staged/user
- [x] Registry USER entries are all `NEVER`
- [x] Lint hint counts the user disposition
- [x] Cross-mission: USER fixes fire (solo: DOI/spase; JUICE: 4; ACE: 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)