### PR TITLE
feat(demo): preview proposed fixes in the web UI + validate the resolver under Pyodide

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -545,6 +545,45 @@ from astralint.base import get_suite, list_all_suites
 from astralint.base.codec import load_file, Codec
 from astralint.reports.html import generate_html_fragment
 
+_FIX_LABELS = {"auto": "Auto-fixable", "staged": "Needs review", "user": "Needs your input"}
+_FIX_COLORS = {"auto": "#16a34a", "staged": "#d97706", "user": "#9333ea"}
+
+def _fix_preview(file, results) -> str:
+    """A read-only preview of what 'astralint fix' would propose (CDF only)."""
+    import html as _html
+    if getattr(file, "extension", "") != "cdf":
+        return ""
+    try:
+        from astralint.resolver.engine import resolve
+        fixes = resolve(file, results.failures_only())
+    except Exception:
+        return ""  # older astralint without the resolver, or nothing to do
+    if not fixes:
+        return ""
+    groups = {"auto": [], "staged": [], "user": []}
+    for fx in fixes:
+        groups[fx.disposition].append(fx)
+    keys = [k for k in ("auto", "staged", "user") if groups[k]]
+    summary = " &middot; ".join(
+        f'<b style="color:{_FIX_COLORS[k]}">{len(groups[k])}</b> {_FIX_LABELS[k].lower()}' for k in keys
+    )
+    out = ['<div style="margin-top:1.5rem;border:1px solid #e5e7eb;border-radius:8px;padding:1rem;">']
+    out.append(f'<div style="font-weight:600;margin-bottom:.25rem;">Proposed fixes — {summary}</div>')
+    out.append('<div style="font-size:.8rem;color:#6b7280;margin-bottom:.75rem;">'
+               'Preview only — run <code>astralint fix &lt;file&gt;</code> in the CLI to apply.</div>')
+    for k in keys:
+        out.append(f'<div style="margin-top:.5rem;font-weight:600;color:{_FIX_COLORS[k]}">'
+                   f'{_FIX_LABELS[k]} ({len(groups[k])})</div>')
+        out.append('<ul style="margin:.25rem 0 0;padding-left:1.25rem;font-size:.85rem;">')
+        for fx in groups[k][:50]:
+            val = "" if fx.value is None else f' = <code>{_html.escape(repr(fx.value))}</code>'
+            out.append(f'<li><b>{_html.escape(fx.attribute)}</b> '
+                       f'<span style="color:#6b7280">{_html.escape(fx.target_path)}</span>{val} '
+                       f'&mdash; {_html.escape(fx.provenance_note)}</li>')
+        out.append('</ul>')
+    out.append('</div>')
+    return "".join(out)
+
 def validate_file_bytes(data: bytes, filename: str, suite_name: str = "ISTP") -> str:
     """Validate file from bytes (for local file uploads)."""
     try:
@@ -561,7 +600,7 @@ def validate_file_bytes(data: bytes, filename: str, suite_name: str = "ISTP") ->
             return f'<div class="status error">Suite "{suite_name}" not found. Available: {list_all_suites()}</div>'
 
         results = suite.run(file)
-        return generate_html_fragment(results)
+        return generate_html_fragment(results) + _fix_preview(file, results)
 
     except Exception as e:
         import traceback
@@ -582,7 +621,7 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             return f'<div class="status error">Suite "{suite_name}" not found. Available: {list_all_suites()}</div>'
 
         results = suite.run(file)
-        return generate_html_fragment(results)
+        return generate_html_fragment(results) + _fix_preview(file, results)
 
     except Exception as e:
         import traceback

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -28,7 +28,7 @@ try:
         # pycdfpp's mutation surface (CDF/save/add_attribute, used by
         # apply_fixes/converge) works under emscripten. Installs astralint from
         # PyPI — the same path the online demo uses — rather than the local wheel.
-        import micropip
+        import micropip  # type: ignore
 
         await micropip.install("astralint")
 

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -21,6 +21,39 @@ try:
 
         assert len(list_all_suites()) > 0
 
+    @pytest.mark.driver_timeout(60 * 2)
+    @copy_files_to_pyodide(
+        file_list=[(_FILE_PATH, _DEST_PATH)], install_wheels=True, recurse_directories=True
+    )
+    @run_in_pyodide(packages=["micropip"])
+    async def test_resolver_mutation_under_pyodide(selenium):
+        # Validates that the resolver's mutation surface works in the browser:
+        # pycdfpp.save / add_attribute / set_value (used by apply_fixes/converge)
+        # must be available in the emscripten build for an in-browser auto-fixer.
+        import numpy as np
+        import pycdfpp
+
+        from astralint.base import get_suite
+        from astralint.codecs.cdf import CdfCodec
+        from astralint.resolver.engine import resolve
+        from astralint.resolver.loop import converge
+
+        cdf = pycdfpp.CDF()
+        cdf.add_variable("flux", np.arange(10, dtype=np.float32), pycdfpp.DataType.CDF_FLOAT)
+        cdf["flux"].add_attribute("VAR_TYPE", "data")
+        cdf.add_attribute("Project", ["Test>Test"], [pycdfpp.DataType.CDF_CHAR])
+        data = bytes(pycdfpp.save(cdf))
+
+        suite = get_suite("ISTP")
+        assert suite is not None
+        file = CdfCodec.load(data)
+        assert file is not None
+        # read-only proposal path (metadata only)
+        assert isinstance(resolve(file, suite.run(file).failures_only()), list)
+        # mutation path: add/set attributes + save back to bytes
+        report, out = converge(data, suite, max_iter=3, filename="x.cdf")
+        assert isinstance(out, bytes)
+
 
 except ImportError:
     print("pytest-pyodide is not installed; skipping Pyodide tests.")

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -21,15 +21,17 @@ try:
 
         assert len(list_all_suites()) > 0
 
-    @pytest.mark.driver_timeout(60 * 2)
-    @copy_files_to_pyodide(
-        file_list=[(_FILE_PATH, _DEST_PATH)], install_wheels=True, recurse_directories=True
-    )
+    @pytest.mark.driver_timeout(60 * 4)
     @run_in_pyodide(packages=["micropip"])
     async def test_resolver_mutation_under_pyodide(selenium):
-        # Validates that the resolver's mutation surface works in the browser:
-        # pycdfpp.save / add_attribute / set_value (used by apply_fixes/converge)
-        # must be available in the emscripten build for an in-browser auto-fixer.
+        # Validates the in-browser auto-fixer: that the resolver runs AND that
+        # pycdfpp's mutation surface (CDF/save/add_attribute, used by
+        # apply_fixes/converge) works under emscripten. Installs astralint from
+        # PyPI — the same path the online demo uses — rather than the local wheel.
+        import micropip
+
+        await micropip.install("astralint")
+
         import numpy as np
         import pycdfpp
 


### PR DESCRIPTION
## Summary

The "safe" first step toward fixes in the web UI: a **read-only fix preview**, plus a Pyodide test that **validates the mutation surface** (gating a later apply+download).

**Web demo:** under the validation report, a new "Proposed fixes" section runs the resolver (`resolve()`, no mutation) and lists the **auto / staged / needs-your-input** dispositions, pointing at `astralint fix`. Metadata-only, so it works in Pyodide. Now that the resolver shipped to PyPI in **v0.7.0**, the demo's `micropip.install('astralint')` picks it up.

**Validation test:** `test_resolver_mutation_under_pyodide` builds a CDF in-browser and runs `resolve()` + `converge()` — exercising `pycdfpp.save` / `add_attribute` / `set_value` under emscripten, the prerequisite for an in-browser **apply + download**. The wasm CI runs it on this PR; a green run means apply+download is feasible and can be a follow-up.

This is the agreed "release → propose-only → validate mutation → add mutation" path: release done (v0.7.0), propose-only here, mutation validated by CI, apply+download next if green.

## Test Plan
- [x] `uv run pytest` — 364 passed (wasm tests skip locally without pytest-pyodide)
- [x] `make lint` — clean
- [x] `_fix_preview` renders dispositions on real files (solo: auto 2 / staged 1 / user 2); returns empty for non-CDF and when there's nothing to propose
- [ ] **wasm CI on this PR** — confirms `resolve()` + `converge()` run under Pyodide (the mutation-surface validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)