### PR TITLE
fix(istp): accept timestamps and dotted versions in Logical_file_id (GA-004)

### DIFF
--- a/src/astralint/resolver/sources/filename.py
+++ b/src/astralint/resolver/sources/filename.py
@@ -4,9 +4,14 @@ from ...base.file import File
 from ...base.validation_result import ValidationResult
 from ..models import ResolverOutput
 
-# ISTP filename stem: <logical_source>_<YYYYMMDD>[_vN]. logical_source is greedy
-# so the trailing date (and optional version) anchor the match.
-_STEM_RE = re.compile(r"^(?P<logical_source>[a-z0-9_-]+)_(?P<date>\d{8})(?:_v(?P<version>\d+))?$")
+# ISTP filename stem: <logical_source>_<Date[time]>[_v<Data_version>]. Per the ISTP
+# File_naming_convention the date is yyyyMMdd, optionally followed by a time
+# (HH/HHmm/HHmmss, optional "t" separator) for sub-daily files, and Data_version
+# may be dotted. logical_source is greedy so the trailing date/version anchor it.
+_STEM_RE = re.compile(
+    r"^(?P<logical_source>[a-z0-9_-]+)_(?P<date>\d{8}(?:t?\d{2,6})?)"
+    r"(?:_v(?P<version>\d+(?:\.\d+)*))?$"
+)
 
 
 def _stem(filename: str) -> str:

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
@@ -6,12 +6,15 @@ severity: ERROR
 suite: ISTP
 
 assertions:
-  # logical_source + date + version. The short names embedded in logical_source
-  # may contain hyphens (e.g. "psp_isois_l2-summary_20180928_v07").
+  # logical_source + Date[time] + v + Data_version, per the ISTP File_naming_convention:
+  # the date is yyyyMMdd, optionally followed by a time (HH/HHmm/HHmmss) with an
+  # optional "t" separator (sub-daily/burst files), and Data_version may be dotted
+  # (matching ISTP-GA-005), e.g. "psp_isois_l2-summary_20180928_v07" or
+  # "mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0".
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: matches
-    pattern: "^[a-z0-9_-]+_\\d{8}(_v\\d+)?$"
-    message: "Logical_file_id should follow: logical_source_YYYYMMDD[_vN] format"
+    pattern: "^[a-z0-9_-]+_\\d{8}(t?\\d{2,6})?(_v\\d+(\\.\\d+)*)?$"
+    message: "Logical_file_id should follow: logical_source_Date[time][_vData_version] format"
 
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: not_empty

--- a/tests/test_logical_file_id_format.py
+++ b/tests/test_logical_file_id_format.py
@@ -1,0 +1,40 @@
+from astralint.base import get_suite
+from astralint.base.file import Attribute, DataType, File
+from astralint.base.validation_result import Severity
+from astralint.resolver.engine import _iter_failures
+
+
+def _file_with_lfid(value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        variables={},
+        attributes={
+            "Logical_file_id": Attribute(
+                name="Logical_file_id", data_type=[DataType.CHAR], shape=[1], values=[value]
+            )
+        },
+    )
+
+
+def _ga004_fails(value: str) -> bool:
+    f = _file_with_lfid(value)
+    suite = get_suite("ISTP")
+    assert suite is not None
+    res = suite.run(f)
+    return any(
+        ref == "ISTP-GA-004" and leaf.severity == Severity.ERROR
+        for ref, leaf in _iter_failures(res.failures_only())
+    )
+
+
+def test_ga004_accepts_timestamp_and_dotted_version():
+    # The ISTP File_naming_convention allows a time component and dotted Data_version.
+    assert not _ga004_fails("mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0")
+    assert not _ga004_fails("mms1_fgm_brst_l2_20190402020713_v5.184.0")
+    assert not _ga004_fails("psp_isois_l2-summary_20180928_v07")  # the doc example
+
+
+def test_ga004_still_rejects_nonconforming():
+    assert _ga004_fails("not a valid logical file id")

--- a/tests/test_resolver_filename.py
+++ b/tests/test_resolver_filename.py
@@ -53,3 +53,15 @@ def test_no_version_token_still_derives_id_and_source():
     src = logical_source_from_filename(f, None, "Logical_source", None)
     assert fid is not None and fid.value == "solo_l2_rpw_20220221"
     assert src is not None and src.value == "solo_l2_rpw"
+
+
+def test_mms_burst_timestamp_and_semver_filename():
+    # ISTP File_naming_convention allows yyyyMMdd + time and a dotted Data_version
+    # (e.g. MMS burst files); the parser must derive all three.
+    f = _file("mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0.cdf")
+    fid = logical_file_id_from_filename(f, None, "Logical_file_id", None)
+    src = logical_source_from_filename(f, None, "Logical_source", None)
+    ver = data_version_from_filename(f, None, "Data_version", None)
+    assert fid is not None and fid.value == "mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0"
+    assert src is not None and src.value == "mms1_fpi_brst_l1b_des-moms-part"
+    assert ver is not None and ver.value == "3.3.0"


### PR DESCRIPTION
## Summary

`ISTP-GA-004` flagged valid CDAWeb data — e.g. `mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0` — as malformed, with `Logical_file_id should follow: logical_source_YYYYMMDD[_vN] format`. Two parts of that regex were wrong:

- **Time component:** the date was `\d{8}` (exactly `yyyyMMdd`), but the file is a `brst` (burst) product with sub-daily granularity → `20170709104703` = `yyyyMMdd`+`HHmmss`. The ISTP **File_naming_convention** explicitly allows this: *"a date format … possibly followed by a time format (`HHmmss`, `HHmm`, or `HH`) with optional `t`"*.
- **Dotted version:** the version was `_v\d+` (integer only), but `Logical_file_id` ends in `v` + `Data_version`, and `ISTP-GA-005` (`DataVersionFormat`) already accepts dotted `Data_version` (`^\d+(\.\d+)*$`). So `_v3.3.0` is valid — the old GA-004 was internally inconsistent with GA-005.

Relaxes GA-004 (and the resolver's filename parser, which used the same strict pattern) to:

```
^[a-z0-9_-]+_\d{8}(t?\d{2,6})?(_v\d+(\.\d+)*)?$
```

so these files validate, and the resolver can now derive/repair the identity globals for MMS burst files (it previously gave up on them). Grounded in the ISTP docs — not a loosening of the standard, a correction toward it.

## Test Plan
- [x] `uv run pytest` — 367 passed
- [x] `make lint` — clean
- [x] GA-004 reproducers: real MMS burst names + dotted versions pass; the doc's `psp_isois_l2-summary_20180928_v07` example still passes; nonsense still fails
- [x] Resolver parser derives `Logical_file_id`/`Logical_source`/`Data_version` (`3.3.0`) from an MMS burst filename
- [x] The real `mms1_fpi_brst_l2_dis-moms_*.cdf` no longer reports a GA-004 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)