### PR TITLE
fix(istp): allow a mixed-case short name in Source_name (GA-007)

### DIFF
--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
@@ -6,10 +6,13 @@ severity: ERROR
 suite: ISTP
 
 assertions:
-  # Format: ABBREV>Full_Name (e.g., "GEOTAIL>Geomagnetic Tail")
+  # Format: ABBREV>Full_Name (e.g., "GEOTAIL>Geomagnetic Tail"). The doc requires
+  # "short and long names, separated by >", but does not mandate an UPPERCASE short
+  # name — real values are mixed-case (e.g. "Lanl-01A>..."). Mirror Descriptor/
+  # DataType formats which allow [A-Za-z].
   - path: "attributes/Source_name/values/[0-9]*"
     check: matches
-    pattern: "^[A-Z0-9_-]+>.+$"
+    pattern: "^[A-Za-z0-9_-]+>.+$"
     message: "Source_name must follow format: ABBREV>Full_Name (e.g., 'GEOTAIL>Geomagnetic Tail')"
 
   - path: "attributes/Source_name/values/[0-9]*"

--- a/tests/test_source_name_format.py
+++ b/tests/test_source_name_format.py
@@ -1,0 +1,41 @@
+from astralint.base import get_suite
+from astralint.base.file import Attribute, DataType, File
+from astralint.base.validation_result import Severity
+from astralint.resolver.engine import _iter_failures
+
+
+def _file_with_source_name(value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        variables={},
+        attributes={
+            "Source_name": Attribute(
+                name="Source_name", data_type=[DataType.CHAR], shape=[1], values=[value]
+            )
+        },
+    )
+
+
+def _ga007_fails(value: str) -> bool:
+    f = _file_with_source_name(value)
+    suite = get_suite("ISTP")
+    assert suite is not None
+    return any(
+        ref == "ISTP-GA-007" and leaf.severity == Severity.ERROR
+        for ref, leaf in _iter_failures(suite.run(f).failures_only())
+    )
+
+
+def test_ga007_accepts_mixed_case_abbrev():
+    # The doc requires "short>long", not an uppercase short name.
+    assert not _ga007_fails("Lanl-01A>Los Alamos National Laboratory 2001")
+    assert not _ga007_fails("GEOTAIL>Geomagnetic Tail")  # the doc example
+    assert not _ga007_fails("PSP>Parker Solar Probe")
+
+
+def test_ga007_still_requires_the_separator():
+    # A bare short name without ">long" is genuinely non-compliant.
+    assert _ga007_fails("dmsp-f13")
+    assert _ga007_fails("mms1")


### PR DESCRIPTION
## Summary

From the regex-rule audit: `ISTP-GA-007` required an **uppercase** short name (`^[A-Z0-9_-]+>...`), so it flagged valid values like `Lanl-01A>Los Alamos National Laboratory 2001` as malformed. The ISTP doc only requires *"short and long names, separated by `>`"* — it never mandates uppercase, and the sibling rules `GA-008` (Descriptor) and `GA-006` (Data_type) already use `[A-Za-z0-9_-]`. So GA-007 was inconsistent and over-strict — the same class of bug as GA-004.

Relaxes the prefix to `[A-Za-z0-9_-]`. Bare short names without the `>long` part are still flagged (that part *is* required by the doc).

Note from the audit: GA-007 was the **only** true false positive among the 10 regex rules. The others that fire on real data (bare `Data_type`/`Descriptor`/`Project` without `>`, non-`yyyymmdd` `Generation_date`, `vNNrNN` versions, paths in `Logical_source`, widthless `FORMAT`) are all genuine deviations the doc backs — left as-is.

## Test Plan
- [x] `uv run pytest` — 366 passed
- [x] `make lint` — clean
- [x] GA-007 reproducers: `Lanl-01A>…` and `GEOTAIL>…`/`PSP>…` pass; bare `dmsp-f13`/`mms1` still fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)