### PR TITLE
feat(demo): in-browser apply+download of auto-fixed CDF + version badge

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -103,6 +103,31 @@
         header h1 { font-size: 2rem; margin-bottom: 0.5rem; }
         header p { opacity: 0.8; }
 
+        .version-badge {
+            display: inline-block;
+            vertical-align: middle;
+            font-size: 0.8rem;
+            font-weight: 600;
+            padding: 0.15rem 0.6rem;
+            border-radius: 999px;
+            background: rgba(255,255,255,0.15);
+            border: 1px solid rgba(255,255,255,0.25);
+            font-family: monospace;
+        }
+
+        .fix-download {
+            margin: 1rem 0 0;
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+
+        .fix-download .fix-note {
+            color: var(--color-text-muted);
+            font-size: 0.85rem;
+        }
+
         .upload-zone {
             background: var(--color-card);
             border: 2px dashed var(--color-border);
@@ -406,7 +431,7 @@
         <div style="display: flex; align-items: center; justify-content: center; gap: 1rem;">
             <img src="https://raw.githubusercontent.com/SciQLop/AstraLint/main/logo.png" alt="AstraLint Logo" style="height: 100px;">
             <div>
-                <h1>AstraLint</h1>
+                <h1>AstraLint <span id="version-badge" class="version-badge" hidden></span></h1>
                 <p>Space Physics Data Conformance Checker — Online Demo</p>
             </div>
         </div>
@@ -583,8 +608,47 @@ def _fix_preview(file, results) -> str:
                        f'<span style="color:#6b7280">{_html.escape(fx.target_path)}</span>{val} '
                        f'&mdash; {_html.escape(fx.provenance_note)}</li>')
         out.append('</ul>')
+    # Hidden marker: the JS reads data-count to decide whether to offer the
+    # in-browser "Apply auto-fixes & download" button (auto fixes only).
+    out.append(f'<div id="alr-autofix" data-count="{len(groups["auto"])}" style="display:none"></div>')
     out.append('</div>')
     return "".join(out)
+
+def astralint_version() -> str:
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        return version("astralint")
+    except PackageNotFoundError:
+        return "unknown"
+
+def _converge_to_json(data: bytes, filename: str, suite_name: str) -> str:
+    """Run the auto-fixer (auto fixes only) and return base64 bytes + counts."""
+    import base64
+    import json
+
+    from astralint.resolver.loop import converge
+
+    suite = get_suite(suite_name)
+    if suite is None:
+        return json.dumps({"error": f'Suite "{suite_name}" not found'})
+    try:
+        report, fixed = converge(bytes(data), suite, filename=filename)
+    except Exception as e:
+        import traceback
+        return json.dumps({"error": str(e), "trace": traceback.format_exc()})
+    return json.dumps({
+        "b64": base64.b64encode(bytes(fixed)).decode("ascii"),
+        "applied": len(report.applied),
+        "remaining_errors": report.remaining_errors,
+    })
+
+def fix_file_bytes(data: bytes, filename: str, suite_name: str = "ISTP") -> str:
+    return _converge_to_json(data, filename, suite_name)
+
+def fix_file_url(url: str, suite_name: str = "ISTP") -> str:
+    from astralint.base.codec import get_remote_file
+    filename = url.rstrip("/").split("/")[-1] or "file.cdf"
+    return _converge_to_json(get_remote_file(url), filename, suite_name)
 
 def validate_file_bytes(data: bytes, filename: str, suite_name: str = "ISTP") -> str:
     """Validate file from bytes (for local file uploads)."""
@@ -635,6 +699,10 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
                 status.innerHTML = '✓ Ready! Upload a file or load from URL to validate.';
                 document.getElementById('app').style.display = 'block';
 
+                const version = await pyodide.runPythonAsync('astralint_version()');
+                const badge = document.getElementById('version-badge');
+                if (badge) { badge.textContent = 'v' + version; badge.hidden = false; }
+
                 autoRunFromQuery();
 
                 // Tell an opener (e.g. the CDFpp WASM demo) we're ready to receive
@@ -682,6 +750,85 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             failedOnly.addEventListener('change', applyFilter);
         }
 
+        // Trigger a browser download of base64-encoded bytes.
+        function downloadBytes(b64, filename) {
+            const bin = atob(b64);
+            const arr = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+            const blobUrl = URL.createObjectURL(new Blob([arr], { type: 'application/octet-stream' }));
+            const a = document.createElement('a');
+            a.href = blobUrl;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+        }
+
+        // "<stem>.fixed.cdf" from the current source — leaves the original untouched.
+        function fixedFileName() {
+            const src = lastName || (lastUrl ? lastUrl.split('/').pop() : '') || 'file.cdf';
+            return src.replace(/\.[^.]+$/, '') + '.fixed.cdf';
+        }
+
+        // Apply the auto fixes (converge) in Pyodide and download the corrected CDF.
+        async function fixAndDownload(btn, note) {
+            btn.disabled = true;
+            btn.textContent = 'Applying…';
+            try {
+                const suite = document.querySelector('input[name="suite"]:checked').value;
+                let resultJson;
+                if (lastBytes) {
+                    pyodide.globals.set('fix_bytes', lastBytes);
+                    pyodide.globals.set('fix_name', lastName || 'file.cdf');
+                    pyodide.globals.set('fix_suite', suite);
+                    resultJson = await pyodide.runPythonAsync('fix_file_bytes(fix_bytes.to_py(), fix_name, fix_suite)');
+                } else if (lastUrl) {
+                    pyodide.globals.set('fix_url', lastUrl);
+                    pyodide.globals.set('fix_suite', suite);
+                    resultJson = await pyodide.runPythonAsync('fix_file_url(fix_url, fix_suite)');
+                } else {
+                    return;
+                }
+                const res = JSON.parse(resultJson);
+                if (res.error) {
+                    btn.textContent = '✗ ' + res.error;
+                    btn.disabled = false;
+                    return;
+                }
+                downloadBytes(res.b64, fixedFileName());
+                btn.textContent = '✓ Downloaded ' + fixedFileName();
+                note.textContent = `Applied ${res.applied} auto-fix${res.applied === 1 ? '' : 'es'} — `
+                    + `${res.remaining_errors} error${res.remaining_errors === 1 ? '' : 's'} remain `
+                    + '(staged/user fixes need the CLI). Re-lint the download to confirm.';
+            } catch (error) {
+                btn.textContent = '✗ Error: ' + error.message;
+                btn.disabled = false;
+                console.error(error);
+            }
+        }
+
+        // After a CDF report renders, offer the apply+download button when the
+        // resolver found auto-fixable issues (marker emitted by _fix_preview).
+        function wireFixDownload() {
+            const marker = document.getElementById('alr-autofix');
+            if (!marker) return;
+            const count = parseInt(marker.dataset.count || '0', 10);
+            if (!count) return;
+
+            const wrap = document.createElement('div');
+            wrap.className = 'fix-download';
+            const btn = document.createElement('button');
+            btn.className = 'url-button';
+            btn.textContent = `Apply ${count} auto-fix${count === 1 ? '' : 'es'} & download`;
+            const note = document.createElement('span');
+            note.className = 'fix-note';
+            btn.addEventListener('click', () => fixAndDownload(btn, note));
+            wrap.appendChild(btn);
+            wrap.appendChild(note);
+            document.getElementById('results').appendChild(wrap);
+        }
+
         // Validate raw bytes. suiteName defaults to the currently-checked radio.
         // Shared by local uploads (processFile) and the postMessage handoff.
         async function validateBytes(uint8Array, name, suiteName) {
@@ -702,6 +849,7 @@ validate_file_bytes(file_bytes.to_py(), file_name, selected_suite)
                 results.innerHTML = html;
 
                 wireReport();
+                wireFixDownload();
 
             } catch (error) {
                 results.innerHTML = '<div class="status error">✗ Error: ' + error.message + '</div>';
@@ -739,6 +887,7 @@ validate_file_url(file_url, selected_suite)
                 results.innerHTML = html;
 
                 wireReport();
+                wireFixDownload();
 
             } catch (error) {
                 results.innerHTML = '<div class="status error">✗ Error loading from URL: ' + error.message + '</div>';

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -594,10 +594,14 @@ def _fix_preview(file, results) -> str:
     summary = " &middot; ".join(
         f'<b style="color:{_FIX_COLORS[k]}">{len(groups[k])}</b> {_FIX_LABELS[k].lower()}' for k in keys
     )
-    out = ['<div style="margin-top:1.5rem;border:1px solid #e5e7eb;border-radius:8px;padding:1rem;">']
+    if groups["auto"]:
+        note = ('Auto fixes can be applied below; staged &amp; user fixes need '
+                '<code>astralint fix &lt;file&gt;</code> in the CLI.')
+    else:
+        note = 'These need review — run <code>astralint fix &lt;file&gt;</code> in the CLI to apply.'
+    out = ['<div style="margin-bottom:1.5rem;border:1px solid #e5e7eb;border-radius:8px;padding:1rem;">']
     out.append(f'<div style="font-weight:600;margin-bottom:.25rem;">Proposed fixes — {summary}</div>')
-    out.append('<div style="font-size:.8rem;color:#6b7280;margin-bottom:.75rem;">'
-               'Preview only — run <code>astralint fix &lt;file&gt;</code> in the CLI to apply.</div>')
+    out.append(f'<div style="font-size:.8rem;color:#6b7280;margin-bottom:.75rem;">{note}</div>')
     for k in keys:
         out.append(f'<div style="margin-top:.5rem;font-weight:600;color:{_FIX_COLORS[k]}">'
                    f'{_FIX_LABELS[k]} ({len(groups[k])})</div>')
@@ -666,7 +670,7 @@ def validate_file_bytes(data: bytes, filename: str, suite_name: str = "ISTP") ->
             return f'<div class="status error">Suite "{suite_name}" not found. Available: {list_all_suites()}</div>'
 
         results = suite.run(file)
-        return generate_html_fragment(results) + _fix_preview(file, results)
+        return _fix_preview(file, results) + generate_html_fragment(results)
 
     except Exception as e:
         import traceback
@@ -687,7 +691,7 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             return f'<div class="status error">Suite "{suite_name}" not found. Available: {list_all_suites()}</div>'
 
         results = suite.run(file)
-        return generate_html_fragment(results) + _fix_preview(file, results)
+        return _fix_preview(file, results) + generate_html_fragment(results)
 
     except Exception as e:
         import traceback
@@ -808,6 +812,14 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             }
         }
 
+        // Move the "Proposed fixes" card to sit just after the summary stat boxes,
+        // so the actionable section reads right below the pass/fail counts.
+        function placeFixPreview() {
+            const card = document.getElementById('alr-autofix')?.parentElement;
+            const summary = document.querySelector('#results .summary');
+            if (card && summary) summary.insertAdjacentElement('afterend', card);
+        }
+
         // After a CDF report renders, offer the apply+download button when the
         // resolver found auto-fixable issues (marker emitted by _fix_preview).
         function wireFixDownload() {
@@ -826,7 +838,9 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             btn.addEventListener('click', () => fixAndDownload(btn, note));
             wrap.appendChild(btn);
             wrap.appendChild(note);
-            document.getElementById('results').appendChild(wrap);
+            // Place the button inside the "Proposed fixes" card (just before the
+            // hidden marker), so it sits with the preview above the report list.
+            marker.parentElement.insertBefore(wrap, marker);
         }
 
         // Validate raw bytes. suiteName defaults to the currently-checked radio.
@@ -849,6 +863,7 @@ validate_file_bytes(file_bytes.to_py(), file_name, selected_suite)
                 results.innerHTML = html;
 
                 wireReport();
+                placeFixPreview();
                 wireFixDownload();
 
             } catch (error) {
@@ -887,6 +902,7 @@ validate_file_url(file_url, selected_suite)
                 results.innerHTML = html;
 
                 wireReport();
+                placeFixPreview();
                 wireFixDownload();
 
             } catch (error) {


### PR DESCRIPTION
## Summary

The web demo already shows a read-only **Proposed fixes** preview (auto / staged / user). This closes the loop: a button to **apply the auto fixes and download the corrected CDF**, entirely in the browser.

- **Apply + download** — when the resolver finds auto-fixable issues, a button appears: *"Apply N auto-fixes & download"*. It runs the resolver loop's `converge` in Pyodide and downloads the result as `<stem>.fixed.cdf`, leaving the original untouched. After applying it reports how many fixes landed and how many errors remain.
- **Auto-only, by design** — staged/user fixes stay preview-only; they need human judgement, so the CLI (`astralint fix`) remains their path.
- **Version badge** — the installed AstraLint version is shown in the header.

Works for both upload and URL sources. The mutation surface was validated under emscripten in #40 (`test_pycdfpp_mutation_under_pyodide`).

## Implementation notes

- Python (`fix_file_bytes` / `fix_file_url`) returns base64 bytes + `applied`/`remaining_errors` as a JSON string — a clean JS↔Pyodide boundary. `_fix_preview` emits a hidden `#alr-autofix` marker carrying the auto-fix count, which the JS reads to decide whether to show the button.
- Version via `importlib.metadata.version("astralint")`.

## Test Plan

- [x] Embedded Python compiles and runs (`fix_file_bytes` → applied/remaining counts; `astralint_version`; marker count) against a real MMS CDF
- [x] App `<script>` passes `node --check`
- [ ] Manual: load a CDF in the deployed demo, confirm the badge shows the version, the button applies + downloads, and re-linting the download shows the auto errors resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)