### PR TITLE
fix(resolver): don't propose a FILLVAL that quantizes onto VALIDMIN (VA-019)

### DIFF
--- a/src/astralint/resolver/sources/type_rules.py
+++ b/src/astralint/resolver/sources/type_rules.py
@@ -47,6 +47,18 @@ def _scalar(attr: Any) -> Any:
     return value
 
 
+def _as_stored(value: Any, data_type: DataType) -> Any:
+    """The value as it will actually be written to the variable, so the range
+    check matches the stored bits. FLOAT32 quantization can move the -1e31 default
+    onto a VALIDMIN that is itself float32(-1e31) — looking outside in double
+    precision while landing exactly on the boundary once stored."""
+    if data_type == DataType.FLOAT32:
+        import numpy as np
+
+        return float(np.float32(value))
+    return value
+
+
 def fillval_outside_range(
     file: File, variable: str | None, attribute: str, failure: ValidationResult | None
 ) -> ResolverOutput | None:
@@ -64,8 +76,9 @@ def fillval_outside_range(
     vmax = _scalar(var.attributes.get("VALIDMAX"))
     if vmin is None or vmax is None:
         return None
+    stored = _as_stored(default, var.data_type)
     try:
-        outside = default < vmin or default > vmax
+        outside = stored < vmin or stored > vmax
     except TypeError:
         return None  # non-order-comparable (e.g. an epoch16 tuple fill)
     if not outside:

--- a/tests/test_resolver_type_rules.py
+++ b/tests/test_resolver_type_rules.py
@@ -129,6 +129,21 @@ def test_fillval_outside_range_none_without_validminmax():
     assert fillval_outside_range(f, "v", "FILLVAL", None) is None
 
 
+def test_fillval_outside_range_none_when_float32_default_quantizes_onto_validmin():
+    from astralint.resolver.sources.type_rules import fillval_outside_range
+
+    # Real MMS master case: VALIDMIN is float32(-1e31) (-9.999999848243207e+30).
+    # The -1e31 default looks below VALIDMIN in double precision, but once written
+    # as FLOAT32 it rounds right back onto VALIDMIN, so the "fix" would not clear
+    # VA-019. The resolver must recognise this and propose nothing.
+    import numpy as np
+
+    vmin = float(np.float32(-1e31))
+    assert (
+        fillval_outside_range(_var_with_range(vmin, 1e5, vmin), "v", "FILLVAL", None) is None
+    )
+
+
 def test_fillval_outside_range_unsigned_proposes_max():
     from astralint.resolver.sources.type_rules import fillval_outside_range
 

--- a/tests/test_resolver_type_rules.py
+++ b/tests/test_resolver_type_rules.py
@@ -130,18 +130,16 @@ def test_fillval_outside_range_none_without_validminmax():
 
 
 def test_fillval_outside_range_none_when_float32_default_quantizes_onto_validmin():
-    from astralint.resolver.sources.type_rules import fillval_outside_range
-
     # Real MMS master case: VALIDMIN is float32(-1e31) (-9.999999848243207e+30).
     # The -1e31 default looks below VALIDMIN in double precision, but once written
     # as FLOAT32 it rounds right back onto VALIDMIN, so the "fix" would not clear
     # VA-019. The resolver must recognise this and propose nothing.
     import numpy as np
 
+    from astralint.resolver.sources.type_rules import fillval_outside_range
+
     vmin = float(np.float32(-1e31))
-    assert (
-        fillval_outside_range(_var_with_range(vmin, 1e5, vmin), "v", "FILLVAL", None) is None
-    )
+    assert fillval_outside_range(_var_with_range(vmin, 1e5, vmin), "v", "FILLVAL", None) is None
 
 
 def test_fillval_outside_range_unsigned_proposes_max():


### PR DESCRIPTION
## The bug

Applying the auto-fix for `FILLVAL` on the MMS master `mms1_fpi_brst_l1b_des-moms-aux_00000000_v01.cdf` claimed to fix VA-019 for `mms1_des_numberdensity_part_brst`, but the corrected file still failed the same rule.

**Root cause — FLOAT32 quantization.** For that variable:
- `VALIDMIN = -9.999999848243207e+30` (that's `-1e31` as stored in FLOAT32)
- `VALIDMAX = 100000`

`fillval_outside_range` compared the **double-precision** `-1e31` default against VALIDMIN. In double, `-1e31 < -9.999999848243207e+30` is `True`, so it judged the default "outside" and proposed it. But once written **as FLOAT32**, `-1e31` rounds right back to `-9.999999848243207e+30` — exactly VALIDMIN. So FILLVAL lands on the range boundary and VA-019 fires again: the fix was a no-op.

## The fix

Compare the value **as it will actually be stored**: quantize the candidate fill to the variable's storage type (FLOAT32) before the range check. When the stored fill is not strictly outside `[VALIDMIN, VALIDMAX]`, propose nothing — this variable is genuinely unfixable by the type-default strategy (VALIDMIN already extends to the fill), so claiming a fix would be wrong.

## Test

`test_fillval_outside_range_none_when_float32_default_quantizes_onto_validmin` reproduces the exact MMS case (fails before, passes after). Verified end-to-end: `resolve()` on the real file now proposes **no** FILLVAL fix for that variable.

This is a separate concern from the demo apply+download (#41); it needs a patch release (0.7.2) to reach the in-browser demo, which installs astralint from PyPI.

## Test Plan
- [x] `make lint` clean
- [x] Full suite: 370 passed
- [x] End-to-end on the real MMS master: no false FILLVAL fix proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)