### PR TITLE
fix(istp): relax four over-strict rules flagging compliant CDAWeb data

### DIFF
--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DisciplineValues.yaml
@@ -6,14 +6,15 @@ severity: WARNING
 suite: ISTP
 
 assertions:
+  # The ISTP doc only enumerates the *space-physics* subset ("The list for space
+  # physics is: …"), so real values like "Planetary Physics>…", "Solar Physics>…"
+  # or "Heliospheric Physics>…" are valid disciplines it doesn't list. Validate the
+  # SPASE "Discipline>Subdiscipline" structure (one or more ">"-separated capitalised
+  # terms) rather than an inevitably-incomplete allow-list; the full controlled
+  # vocabulary lives in the SPASE base model.
   - path: "attributes/Discipline/values/[0-9]*"
-    check: in
+    check: matches
     error_if_no_match: false
-    values:
-      - "Solar Physics>Heliospheric Physics"
-      - "Space Physics>Interplanetary Studies"
-      - "Space Physics>Magnetospheric Science"
-      - "Space Physics>Ionospheric Science"
-      - "Space Physics>Astrophysics Science"
-    message: "Discipline should use a standard ISTP value (e.g., 'Space Physics>Magnetospheric Science')"
+    pattern: "^[A-Z][A-Za-z ]*(>[A-Z][A-Za-z ]*)+$"
+    message: "{% if valid %}Attribute Discipline has value '{{ value }}'{% else %}Discipline should follow the SPASE 'Discipline>Subdiscipline' form, e.g. 'Space Physics>Magnetospheric Science' (the ISTP doc lists only the space-physics subset; see the SPASE controlled vocabulary for the full list){% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
@@ -8,12 +8,16 @@ suite: ISTP
 assertions:
   # logical_source + Date[time] + v + Data_version, per the ISTP File_naming_convention:
   # the date is yyyyMMdd, optionally followed by a time (HH/HHmm/HHmmss) with an
-  # optional "t" separator (sub-daily/burst files), and Data_version may be dotted
+  # optional "t"/"T" separator (sub-daily/burst files), and Data_version may be dotted
   # (matching ISTP-GA-005), e.g. "psp_isois_l2-summary_20180928_v07" or
   # "mms1_fpi_brst_l1b_des-moms-part_20170709104703_v3.3.0".
+  # Case-insensitive: the naming doc only *recommends* lowercase ("unless absolutely
+  # necessary"), so canonical uppercase ids like "AC_H2_SIS_20101105_V06" (ACE) or
+  # "GE_K0_CPI_19921231_V02" (Geotail) are well-formed, not malformed. The lowercase
+  # preference is a separate WARNING (ISTP-GA-017).
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: matches
-    pattern: "^[a-z0-9_-]+_\\d{8}(t?\\d{2,6})?(_v\\d+(\\.\\d+)*)?$"
+    pattern: "(?i)^[a-z0-9_-]+_\\d{8}([t]?\\d{2,6})?(_v\\d+(\\.\\d+)*)?$"
     message: "Logical_file_id should follow: logical_source_Date[time][_vData_version] format"
 
   - path: "attributes/Logical_file_id/values/[0-9]*"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdLowercase.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdLowercase.yaml
@@ -1,0 +1,17 @@
+name: LogicalFileIdLowercase
+description: "Logical_file_id should preferably be all-lowercase"
+url: "https://istp-metadata.readthedocs.io/en/latest/source/filenaming-dataset-naming-recommendations.html"
+reference: "ISTP-GA-017"
+severity: WARNING
+suite: ISTP
+
+assertions:
+  # The ISTP file-naming recommendation: "Use all lower case filenames unless
+  # absolutely necessary, to avoid confusion with files that differ only by case."
+  # This is a preference, not a format requirement (the format check ISTP-GA-004 is
+  # case-insensitive), so an uppercase id is flagged softly here, not as an error.
+  - path: "attributes/Logical_file_id/values/[0-9]*"
+    check: matches
+    error_if_no_match: false
+    pattern: "^[^A-Z]*$"
+    message: "{% if valid %}Logical_file_id '{{ value }}' is lowercase{% else %}Logical_file_id '{{ value }}' should preferably be all-lowercase (ISTP recommends lowercase filenames unless absolutely necessary){% endif %}"

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DisplayTypeValues.yaml
@@ -6,17 +6,12 @@ severity: WARNING
 suite: ISTP
 
 assertions:
+  # The base display type may carry plotting parameters after ">" — the ISTP doc's
+  # own example uses "spectrogram>y=energy,z=Flux_H(*,1)". Match the base type
+  # (before any ">"), case-insensitively, tolerating surrounding whitespace.
   - path: "variables/.*/attributes/DISPLAY_TYPE/values/[0-9]*"
-    check: in
+    check: matches
     error_if_no_match: false
-    values:
-      - time_series
-      - spectrogram
-      - stack_plot
-      - image
-      - no_plot
-      - orbit
-      - plasmagram
-      - movie
-    message: "{% if valid %}Attribute DISPLAY_TYPE of {{ variable }} has value '{{ value }}'{% else %}Attribute DISPLAY_TYPE of {{ variable }} has value '{{ value }}', expected time_series, spectrogram, stack_plot, image, no_plot, orbit, plasmagram, or movie{% endif %}"
+    pattern: "(?i)^\\s*(time_series|spectrogram|stack_plot|image|no_plot|orbit|plasmagram|movie)\\s*(>.*)?$"
+    message: "{% if valid %}Attribute DISPLAY_TYPE of {{ variable }} has value '{{ value }}'{% else %}Attribute DISPLAY_TYPE of {{ variable }} has value '{{ value }}', expected time_series, spectrogram, stack_plot, image, no_plot, orbit, plasmagram, or movie (optionally followed by '>' plot parameters){% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/FormatSpecifier.yaml
@@ -6,10 +6,14 @@ severity: WARNING
 suite: ISTP
 
 assertions:
-  # Common Fortran formats: F, E, I, A, G followed by width and optional decimal places
+  # Fortran edit descriptor: optional scale factor (nP) and/or repeat count, then a
+  # descriptor letter — A/I/E/F/D/G plus Z (hex) — width, and optional decimals.
+  # Fortran is case-insensitive, so lowercase ("f12.8", "a5") and forms like
+  # "1PE9.2" or "Z10.8" are valid. Width is still required (widthless "I"/"F"/"B"
+  # remain non-conformant per the doc's "F10.3"-style examples).
   - path: "variables/.*/attributes/FORMAT/values/[0-9]*"
     check: matches
     error_if_no_match: false
-    pattern: "^[AIEFDG]\\d+(\\.\\d+)?$"
+    pattern: "(?i)^\\s*(\\d+p)?\\d*[aiefdgz]\\d+(\\.\\d+)?\\s*$"
     message: "{% if valid %}Attribute FORMAT of {{ variable }} has value '{{ value }}'{% else %}Attribute FORMAT of {{ variable }} has value '{{ value }}', expected a valid Fortran format specifier (e.g., F10.2, E12.4, I5, A20, G13.6){% endif %}"
 

--- a/tests/test_istp_false_positive_fixes.py
+++ b/tests/test_istp_false_positive_fixes.py
@@ -1,0 +1,120 @@
+"""Regression tests for ISTP false-positive fixes (case/format strictness).
+
+Each rule below was firing on real, standards-compliant CDAWeb data. The fixes
+relax them to what the ISTP doc actually permits; these tests pin the accepted
+forms while keeping the genuinely-malformed ones rejected.
+"""
+
+from astralint.base import get_suite
+from astralint.base.file import Attribute, DataType, File, Variable
+from astralint.resolver.engine import _iter_failures
+
+
+def _fires(file: File, reference: str) -> bool:
+    suite = get_suite("ISTP")
+    assert suite is not None
+    res = suite.run(file)
+    return any(ref == reference for ref, _leaf in _iter_failures(res.failures_only()))
+
+
+def _global(name: str, value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        variables={},
+        attributes={
+            name: Attribute(name=name, data_type=[DataType.CHAR], shape=[1], values=[value])
+        },
+    )
+
+
+def _var_attr(attr: str, value: str) -> File:
+    return File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        attributes={},
+        variables={
+            "v": Variable(
+                name="v",
+                shape=[10],
+                compression="NONE",
+                data_type=DataType.FLOAT32,
+                record_variance=True,
+                attributes={
+                    attr: Attribute(name=attr, data_type=[DataType.CHAR], shape=[1], values=[value])
+                },
+            )
+        },
+    )
+
+
+# ---- GA-004: Logical_file_id format is case-insensitive (canonical uppercase ids) ----
+
+
+def test_ga004_accepts_uppercase_canonical_ids():
+    for value in (
+        "AC_H2_SIS_20101105_V06",  # ACE
+        "GE_K0_CPI_19921231_V02",  # Geotail
+        "solo_L1_rpw-lfr-surv-asm_20200617_V03",  # Solar Orbiter (mixed case)
+    ):
+        assert not _fires(_global("Logical_file_id", value), "ISTP-GA-004"), value
+
+
+def test_ga004_still_rejects_malformed():
+    assert _fires(_global("Logical_file_id", "not a valid logical file id"), "ISTP-GA-004")
+
+
+# ---- GA-017: lowercase is only a (soft) recommendation ----
+
+
+def test_ga017_warns_on_uppercase_but_not_lowercase():
+    assert _fires(_global("Logical_file_id", "AC_H2_SIS_20101105_V06"), "ISTP-GA-017")
+    assert not _fires(_global("Logical_file_id", "ac_h2_sis_20101105_v06"), "ISTP-GA-017")
+
+
+# ---- VA-005: DISPLAY_TYPE may carry ">" plot params; case/space tolerant ----
+
+
+def test_va005_accepts_parameterized_and_cased_display_type():
+    for value in (
+        "spectrogram>y=energy,z=Flux_H(*,1)",  # the doc's own example form
+        "TIME_SERIES",
+        "time_series ",
+    ):
+        assert not _fires(_var_attr("DISPLAY_TYPE", value), "ISTP-VA-005"), value
+
+
+def test_va005_still_rejects_unknown_type():
+    assert _fires(_var_attr("DISPLAY_TYPE", "bogus_plot"), "ISTP-VA-005")
+
+
+# ---- VA-010: FORMAT accepts valid Fortran in any case (+ Z hex, nP scale) ----
+
+
+def test_va010_accepts_valid_fortran_variants():
+    for value in ("f12.8", "a5", "1PE9.2", "Z10.8", "F5.2   ", "I10"):
+        assert not _fires(_var_attr("FORMAT", value), "ISTP-VA-010"), value
+
+
+def test_va010_still_rejects_widthless_and_garbage():
+    assert _fires(_var_attr("FORMAT", "I"), "ISTP-VA-010")  # no width
+    assert _fires(_var_attr("FORMAT", "not-a-format"), "ISTP-VA-010")
+
+
+# ---- GA-009: Discipline validated by structure, not an incomplete allow-list ----
+
+
+def test_ga009_accepts_non_space_physics_disciplines():
+    for value in (
+        "Planetary Physics>Particles",
+        "Solar Physics>Interplanetary Studies",
+        "Heliospheric Physics>Particles",
+        "Space Physics>Planetary Physics>Particles",  # multi-level
+    ):
+        assert not _fires(_global("Discipline", value), "ISTP-GA-009"), value
+
+
+def test_ga009_still_rejects_unstructured():
+    assert _fires(_global("Discipline", "nonsense"), "ISTP-GA-009")


### PR DESCRIPTION
## Summary

A false-positive hunt (aggregating every rule firing over **101 real published CDAWeb files**, then judging each against the bundled ISTP doc) found four rules flagging standards-**compliant** data — the same family as the GA-004/GA-007 fixes. Each relaxation is grounded in the doc; genuinely-malformed values still fail, pinned by new reproducer tests.

| Rule | Sev | Fix | Corpus (before → after) |
|------|-----|-----|------|
| **GA-004** Logical_file_id | ERROR | Case-insensitive — the naming doc only *recommends* lowercase ("unless absolutely necessary"); `AC_H2_SIS_20101105_V06` (ACE), `GE_K0_CPI_19921231_V02` (Geotail) are well-formed. | 62 → 39 |
| **GA-017** *(new)* | WARNING | Soft nudge toward all-lowercase ids (the recommendation GA-004 no longer enforces as an error). | 0 → 27 |
| **VA-005** DISPLAY_TYPE | WARNING | Accept base type + `>` plot params — the doc's own example is `spectrogram>y=energy,z=Flux_H(*,1)`. Case/space tolerant. | 199 → 153 |
| **VA-010** FORMAT | WARNING | Accept valid Fortran in any case (`f12.8`, `a5`), plus hex `Z` and scale-factor `nP` (`1PE9.2`). Width still required. | 669 → 59 |
| **GA-009** Discipline | WARNING | Validate the SPASE `Discipline>Subdiscipline` structure rather than an allow-list the doc itself scopes to space physics ("The list for space physics is: …"). | 19 → 0 |

The remaining firings are all **genuine** deviations (`.cdf` extension in the id, embedded spaces, missing date, MAVEN `vv02r01`, `no_plor` typo, VAR_TYPE values misused as DISPLAY_TYPE).

## Not done on purpose (doc doesn't clearly permit — flagging for discussion)
- **Cluster CSA filenames** (`C1_CP_FGM_FULL__20180302_000000_20180303_000000_V180731`) use underscore-separated begin–end datetime ranges; the doc shows `T`-separated/compact times.
- **`plasma_movie>…`** DISPLAY_TYPE (MMS HPCA) isn't in the documented value list.

## Also confirmed correct (not false positives) during the hunt
- VA-020/021/022 length hard limits — the doc intro states exactly 50/120/20 for FIELDNAM/CATDESC/LABLAXIS.
- VA-019 FILLVAL-outside-range — the doc explicitly requires it and even documents the `-1e31` quantization (validates PR #42).

## Test Plan
- [x] New `tests/test_istp_false_positive_fixes.py` (9 tests): each accepted form passes, each malformed form still fails
- [x] `make lint` clean
- [x] Full suite: 379 passed
- [x] Re-aggregated the 101-file corpus to confirm the drops above

🤖 Generated with [Claude Code](https://claude.com/claude-code)