### PR TITLE
perf(rules): index flattened paths by variable/attribute (45s → 1.2s on a large file)

### DIFF
--- a/src/astralint/base/yaml_rules/assertions/base.py
+++ b/src/astralint/base/yaml_rules/assertions/base.py
@@ -1,13 +1,23 @@
 import re
+from functools import lru_cache
 from typing import Annotated, Any, Union
 
-from jinja2 import Environment, TemplateError
+from jinja2 import Environment, Template, TemplateError
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ...file import File
 from ...validation_result import Severity, ValidationResult, ValidationResultGroup
 
 _jinja_env = Environment()
+
+
+@lru_cache(maxsize=512)
+def _compiled_template(template: str) -> Template:
+    # Rule message templates come from a small fixed set; compiling each once
+    # (instead of on every match) avoids tens of thousands of Jinja compilations
+    # on large files.
+    return _jinja_env.from_string(template)
+
 
 _TARGET_PATTERN = re.compile(
     r"^variables/(?P<var>[^/]+)/attributes/(?P<attr>[^/]+)"
@@ -18,7 +28,7 @@ _TARGET_PATTERN = re.compile(
 
 def render_message(template: str, context: dict) -> str:
     try:
-        return _jinja_env.from_string(template).render(context)
+        return _compiled_template(template).render(context)
     except TemplateError as e:
         return f"[template error: {e}] template: {template}"
 
@@ -60,8 +70,21 @@ import weakref
 _FLATTEN_CACHE: dict[int, list[tuple[str, Any]]] = {}
 
 
+# Indexes of flattened entries bucketed by variable name and by attribute name, so
+# a rule targeting a specific variable or attribute (the common case) scans only the
+# relevant slice instead of the whole file. Keyed on id(obj) and invalidated by the
+# same weakref as the flatten cache.
+_Indexes = tuple[
+    dict[str | None, list[tuple[str, Any]]],  # by variable name
+    dict[str | None, list[tuple[str, Any]]],  # by attribute name
+    list[tuple[str, Any]],  # the full flattened list
+]
+_INDEX_CACHE: dict[int, _Indexes] = {}
+
+
 def clear_flatten_cache() -> None:
     _FLATTEN_CACHE.clear()
+    _INDEX_CACHE.clear()
 
 
 def flatten_object(obj: Any) -> list[tuple[str, Any]]:
@@ -100,11 +123,75 @@ def flatten_object(obj: Any) -> list[tuple[str, Any]]:
     return results
 
 
+# The flattened path grammar is fixed (variable/attribute names never contain '/'),
+# so the variable and attribute segments sit at known indices.
+def _var_of_path(flat_path: str) -> str | None:
+    parts = flat_path.split("/", 2)
+    return parts[1] if len(parts) >= 2 and parts[0] == "variables" else None
+
+
+def _attr_of_path(flat_path: str) -> str | None:
+    parts = flat_path.split("/", 4)
+    if len(parts) >= 2 and parts[0] == "attributes":
+        return parts[1]
+    if len(parts) >= 4 and parts[0] == "variables" and parts[2] == "attributes":
+        return parts[3]
+    return None
+
+
+def _indexes(obj: Any) -> _Indexes:
+    key = id(obj)
+    cached = _INDEX_CACHE.get(key)
+    if cached is not None:
+        return cached
+    flattened = flatten_object(obj)
+    by_var: dict[str | None, list[tuple[str, Any]]] = {}
+    by_attr: dict[str | None, list[tuple[str, Any]]] = {}
+    for entry in flattened:
+        by_var.setdefault(_var_of_path(entry[0]), []).append(entry)
+        by_attr.setdefault(_attr_of_path(entry[0]), []).append(entry)
+    result: _Indexes = (by_var, by_attr, flattened)
+    try:
+        weakref.finalize(obj, _INDEX_CACHE.pop, key, None)
+        _INDEX_CACHE[key] = result
+    except TypeError:
+        pass
+    return result
+
+
+_REGEX_SPECIAL = re.compile(r"[.*+?^$()\[\]{}|\\]")
+
+
+def _literal(segment: str | None) -> str | None:
+    return segment if segment is not None and not _REGEX_SPECIAL.search(segment) else None
+
+
+def _candidates(obj: Any, path: str) -> list[tuple[str, Any]]:
+    """Narrow the entries a rule path can match. Any literal variable or attribute
+    name it pins means every match lives under that variable/attribute, so we scan
+    only that bucket. Prefer the variable bucket (one variable's attributes) — it is
+    the most selective; fall back to the attribute bucket, then the whole file."""
+    by_var, by_attr, flattened = _indexes(obj)
+    parts = path.split("/", 4)
+    if len(parts) >= 2 and parts[0] == "variables" and (var := _literal(parts[1])) is not None:
+        return by_var.get(var, [])
+    attr: str | None = None
+    if len(parts) >= 2 and parts[0] == "attributes":
+        attr = _literal(parts[1])
+    elif len(parts) >= 4 and parts[0] == "variables" and parts[2] == "attributes":
+        attr = _literal(parts[3])
+    return by_attr.get(attr, []) if attr is not None else flattened
+
+
+@lru_cache(maxsize=1024)
+def _anchored_regex(pattern: str) -> re.Pattern:
+    return re.compile("^" + pattern + "$")
+
+
 def resolve_path(obj: Any, path: str) -> list[tuple[str, Any]]:
     """Returns matching (path, value) pairs for a '/' separated path with regex support."""
-    flattened = flatten_object(obj)
-    rx = re.compile("^" + path + "$")
-    return list(filter(lambda kv: rx.match(kv[0]), flattened))
+    rx = _anchored_regex(path)
+    return [kv for kv in _candidates(obj, path) if rx.match(kv[0])]
 
 
 _CAPTURE_RE = re.compile(r"\{(\w+)(?::([^}]+))?\}")
@@ -129,10 +216,9 @@ def parse_captures(path: str) -> tuple[str, list[str]]:
 def resolve_path_with_captures(obj: Any, path: str) -> list[tuple[str, Any, dict[str, str]]]:
     """Like resolve_path but extracts captured values from {name} placeholders."""
     pattern, capture_names = parse_captures(path)
-    flattened = flatten_object(obj)
-    rx = re.compile("^" + pattern + "$")
+    rx = _anchored_regex(pattern)
     results: list[tuple[str, Any, dict[str, str]]] = []
-    for flat_path, value in flattened:
+    for flat_path, value in _candidates(obj, path):
         m = rx.match(flat_path)
         if m:
             captured = {name: m.group(name) for name in capture_names}

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -59,6 +59,57 @@ def test_parse_captures_inner_groups():
     assert m.group("var") == "LFR_test"
 
 
+def test_resolve_path_bucketing_equals_full_scan():
+    """The variable/attribute bucketing in resolve_path_with_captures must return
+    exactly what a brute-force regex scan over the whole flattened file would."""
+    from astralint.base.file import Attribute, DataType, File, Variable
+    from astralint.base.yaml_rules.assertions.base import flatten_object
+
+    def _attr(name: str, value: str) -> Attribute:
+        return Attribute(name=name, data_type=[DataType.CHAR], shape=[1], values=[value])
+
+    def _var(name: str) -> Variable:
+        return Variable(
+            name=name,
+            shape=[10],
+            compression="NONE",
+            data_type=DataType.FLOAT32,
+            record_variance=True,
+            attributes={"CATDESC": _attr("CATDESC", "desc"), "VAR_TYPE": _attr("VAR_TYPE", "data")},
+        )
+
+    file = File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        attributes={"Project": _attr("Project", "ISTP>x"), "CATDESC": _attr("CATDESC", "g")},
+        variables={"alpha": _var("alpha"), "beta": _var("beta")},
+    )
+
+    def brute(path: str):
+        pattern, names = parse_captures(path)
+        rx = re.compile("^" + pattern + "$")
+        out = []
+        for fp, v in flatten_object(file):
+            m = rx.match(fp)
+            if m:
+                out.append((fp, v, {n: m.group(n) for n in names}))
+        return out
+
+    for path in (
+        "variables/.*/attributes/CATDESC/values/[0-9]*",  # wildcard var, literal attr
+        "variables/alpha/attributes/VAR_TYPE/values/[0-9]*",  # literal var + attr
+        "variables/alpha/data_type",  # literal var, non-attribute field
+        "attributes/Project/values/[0-9]*",  # global attribute
+        "attributes/CATDESC/values/[0-9]*",  # global attr sharing a name with var attrs
+        "variables/{var}/attributes/CATDESC",  # capture var
+        "variables/.*/attributes/.*",  # wildcard var and attr (full scan)
+        "variables/.*",  # all variable sub-paths
+    ):
+        got = sorted(map(str, resolve_path_with_captures(file, path)))
+        assert got == sorted(map(str, brute(path))), path
+
+
 def test_resolve_path_with_captures_basic(mock_file):
     matches = resolve_path_with_captures(mock_file, "variables/{var}/data_type")
     assert len(matches) >= 1


### PR DESCRIPTION
## Summary

Validating large files was extremely slow — the THEMIS ESA file `tha_l2_esa_20180119_v01.fixed.cdf` (383 variables, 5,866 attributes) took **~45 s**. Two causes, both O(rules × whole-file):

1. **`resolve_path_with_captures`** regex-matched every assertion path against the *entire* flattened file (~52k entries), and re-scanned it for **each per-variable capture expansion** — ~**230 million** `re.match` calls.
2. **`render_message`** recompiled its Jinja template on every match (~19k compilations).

## Fix (no change to validation output)

- **Bucket the flattened entries by variable name and by attribute name**, built once per file and invalidated by the same weakref as the existing flatten cache. The flattened path grammar is fixed (variable/attribute names never contain `/`), so when a rule path pins a literal variable or attribute name, every possible match lives under it — resolution scans that bucket instead of the whole file. Prefer the variable bucket (one variable's attributes — most selective), then the attribute bucket, then the full list.
- **Cache compiled Jinja templates and compiled path regexes** (`lru_cache`).

## Result

`tha_l2_esa_20180119_v01.fixed.cdf`: **~45 s → ~1.2 s** (~37×), with a **byte-identical failure set** (verified by hashing the sorted `(reference, target, severity, message)` of every failing leaf).

## Correctness

- Failure-set signature **identical** on the THEMIS file and three other diverse files (ACE, MMS, an ISTP master) — compared main vs this branch.
- New test `test_resolve_path_bucketing_equals_full_scan` pins the bucketed resolution to a brute-force full scan across literal-var / literal-attr / wildcard / capture / global-attribute path shapes.
- Full suite: 371 passed.

## Test Plan
- [x] `make lint` clean
- [x] Full suite passes (371)
- [x] Result signature unchanged vs `main` on 4 real multi-mission files