### PR TITLE
Positive phrasing for passing ISTP rule messages (stacked on #45)

### DIFF
--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DOIFormat.yaml
@@ -10,4 +10,4 @@ assertions:
     check: matches
     error_if_no_match: false
     pattern: "^https://doi\\.org/.+/.+$"
-    message: "DOI must be of the form https://doi.org/PREFIX/SUFFIX"
+    message: "{% if valid %}DOI uses the https://doi.org/PREFIX/SUFFIX form{% else %}DOI must be of the form https://doi.org/PREFIX/SUFFIX{% endif %}"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataTypeFormat.yaml
@@ -11,9 +11,9 @@ assertions:
   - path: "attributes/Data_type/values/[0-9]*"
     check: matches
     pattern: "^[A-Za-z0-9_-]+>.+$"
-    message: "Data_type must follow format: ABBREV>Full_description (e.g., 'L2-Summary>level 2 summary')"
+    message: "{% if valid %}Data_type follows the ABBREV>Full_description format{% else %}Data_type must follow format: ABBREV>Full_description (e.g., 'L2-Summary>level 2 summary'){% endif %}"
 
   - path: "attributes/Data_type/values/[0-9]*"
     check: not_empty
-    message: "Data_type cannot be empty"
+    message: "{% if valid %}Data_type is present{% else %}Data_type cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DataVersionFormat.yaml
@@ -9,9 +9,9 @@ assertions:
   - path: "attributes/Data_version/values/[0-9]*"
     check: matches
     pattern: "^\\d+(\\.\\d+)*$"
-    message: "Data_version must be numeric (e.g., '1', '1.0', '01')"
+    message: "{% if valid %}Data_version is numeric{% else %}Data_version must be numeric (e.g., '1', '1.0', '01'){% endif %}"
 
   - path: "attributes/Data_version/values/[0-9]*"
     check: not_empty
-    message: "Data_version cannot be empty"
+    message: "{% if valid %}Data_version is present{% else %}Data_version cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/DescriptorFormat.yaml
@@ -10,9 +10,9 @@ assertions:
   - path: "attributes/Descriptor/values/[0-9]*"
     check: matches
     pattern: "^[A-Za-z0-9_-]+>.+$"
-    message: "Descriptor must follow format: ABBREV>Full_description"
+    message: "{% if valid %}Descriptor follows the ABBREV>Full_description format{% else %}Descriptor must follow format: ABBREV>Full_description{% endif %}"
 
   - path: "attributes/Descriptor/values/[0-9]*"
     check: not_empty
-    message: "Descriptor cannot be empty"
+    message: "{% if valid %}Descriptor is present{% else %}Descriptor cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/GenerationDateFormat.yaml
@@ -10,4 +10,4 @@ assertions:
     check: matches
     error_if_no_match: false
     pattern: "^\\d{8}$"
-    message: "Generation_date must use yyyymmdd format"
+    message: "{% if valid %}Generation_date uses yyyymmdd format{% else %}Generation_date must use yyyymmdd format{% endif %}"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/InstrumentTypeValues.yaml
@@ -28,5 +28,5 @@ assertions:
       - "Particles (space)"
       - "Plasma and Solar Wind"
       - "Radio and Plasma Waves (space)"
-    message: "Instrument_type should use a standard ISTP value"
+    message: "{% if valid %}Instrument_type uses a standard ISTP value{% else %}Instrument_type should use a standard ISTP value{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LinkCountConsistency.yaml
@@ -11,10 +11,10 @@ assertions:
     error_if_no_match: false
     operator: "="
     other_path: "attributes/LINK_TEXT/shape/0"
-    message: "HTTP_LINK and LINK_TEXT must have the same number of entries"
+    message: "{% if valid %}HTTP_LINK and LINK_TEXT have the same number of entries{% else %}HTTP_LINK and LINK_TEXT must have the same number of entries{% endif %}"
   - path: "attributes/HTTP_LINK/shape/0"
     check: compare_to
     error_if_no_match: false
     operator: "="
     other_path: "attributes/LINK_TITLE/shape/0"
-    message: "HTTP_LINK and LINK_TITLE must have the same number of entries"
+    message: "{% if valid %}HTTP_LINK and LINK_TITLE have the same number of entries{% else %}HTTP_LINK and LINK_TITLE must have the same number of entries{% endif %}"

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalFileIdFormat.yaml
@@ -18,9 +18,9 @@ assertions:
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: matches
     pattern: "(?i)^[a-z0-9_-]+_\\d{8}([t]?\\d{2,6})?(_v\\d+(\\.\\d+)*)?$"
-    message: "Logical_file_id should follow: logical_source_Date[time][_vData_version] format"
+    message: "{% if valid %}Logical_file_id follows the logical_source_Date[time][_vData_version] format{% else %}Logical_file_id should follow: logical_source_Date[time][_vData_version] format{% endif %}"
 
   - path: "attributes/Logical_file_id/values/[0-9]*"
     check: not_empty
-    message: "Logical_file_id cannot be empty"
+    message: "{% if valid %}Logical_file_id is present{% else %}Logical_file_id cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/LogicalSourceFormat.yaml
@@ -10,9 +10,9 @@ assertions:
   - path: "attributes/Logical_source/values/[0-9]*"
     check: matches
     pattern: "^[a-zA-Z0-9-]+_[a-zA-Z0-9_-]+_[a-zA-Z0-9_-]+$"
-    message: "Logical_source must follow format: source_descriptor_datatype (lowercase with underscores)"
+    message: "{% if valid %}Logical_source follows the source_descriptor_datatype format{% else %}Logical_source must follow format: source_descriptor_datatype (lowercase with underscores){% endif %}"
 
   - path: "attributes/Logical_source/values/[0-9]*"
     check: not_empty
-    message: "Logical_source cannot be empty"
+    message: "{% if valid %}Logical_source is present{% else %}Logical_source cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/ProjectFormat.yaml
@@ -13,10 +13,10 @@ assertions:
     check: matches
     error_if_no_match: false
     pattern: "^[A-Za-z0-9_ -]+>.+$"
-    message: "Project must follow format: ABBREV>Full_Name (e.g., 'ISTP>International Solar-Terrestrial Physics')"
+    message: "{% if valid %}Project follows the ABBREV>Full_Name format{% else %}Project must follow format: ABBREV>Full_Name (e.g., 'ISTP>International Solar-Terrestrial Physics'){% endif %}"
 
   - path: "attributes/Project/values/[0-9]*"
     check: not_empty
     error_if_no_match: false
-    message: "Project cannot be empty"
+    message: "{% if valid %}Project is present{% else %}Project cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/SourceNameFormat.yaml
@@ -13,9 +13,9 @@ assertions:
   - path: "attributes/Source_name/values/[0-9]*"
     check: matches
     pattern: "^[A-Za-z0-9_-]+>.+$"
-    message: "Source_name must follow format: ABBREV>Full_Name (e.g., 'GEOTAIL>Geomagnetic Tail')"
+    message: "{% if valid %}Source_name follows the ABBREV>Full_Name format{% else %}Source_name must follow format: ABBREV>Full_Name (e.g., 'GEOTAIL>Geomagnetic Tail'){% endif %}"
 
   - path: "attributes/Source_name/values/[0-9]*"
     check: not_empty
-    message: "Source_name cannot be empty"
+    message: "{% if valid %}Source_name is present{% else %}Source_name cannot be empty{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
+++ b/src/astralint/suites/ISTP/rules/GlobalAttributes/TextNotEmpty.yaml
@@ -10,5 +10,5 @@ assertions:
   # prescribe a minimum length, so only emptiness is enforced as an error.
   - path: "attributes/TEXT/values/[0-9]*"
     check: not_empty
-    message: "TEXT global attribute cannot be empty - must describe the data"
+    message: "{% if valid %}TEXT global attribute is present{% else %}TEXT global attribute cannot be empty - must describe the data{% endif %}"
 

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/DataVariableAttributes.yaml
@@ -24,7 +24,7 @@ assertions:
             - VALIDMAX
           message: "{% if valid %}{{ variable }} has all required data attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
         - check: any_of
-          message: "Data variable must have LABLAXIS or LABL_PTR_1"
+          message: "{% if valid %}Data variable has LABLAXIS or LABL_PTR_1{% else %}Data variable must have LABLAXIS or LABL_PTR_1{% endif %}"
           assertions:
             - path: "variables/{var}/attributes/LABLAXIS"
               check: exists
@@ -33,7 +33,7 @@ assertions:
               check: exists
               message: ""
         - check: any_of
-          message: "Data variable must have UNITS or UNIT_PTR"
+          message: "{% if valid %}Data variable has UNITS or UNIT_PTR{% else %}Data variable must have UNITS or UNIT_PTR{% endif %}"
           assertions:
             - path: "variables/{var}/attributes/UNITS"
               check: exists

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/MetadataVariableAttributes.yaml
@@ -22,7 +22,7 @@ assertions:
             - FIELDNAM
           message: "{% if valid %}{{ variable }} has required metadata attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
         - check: any_of
-          message: "Metadata variable must have FORMAT or FORM_PTR"
+          message: "{% if valid %}Metadata variable has FORMAT or FORM_PTR{% else %}Metadata variable must have FORMAT or FORM_PTR{% endif %}"
           assertions:
             - path: "variables/{var}/attributes/FORMAT"
               check: exists

--- a/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
+++ b/src/astralint/suites/ISTP/rules/VariableAttributes/SupportDataVariableAttributes.yaml
@@ -22,7 +22,7 @@ assertions:
             - FIELDNAM
           message: "{% if valid %}{{ variable }} has required support_data attributes{% else %}{{ variable }} missing required attribute(s): {{ missing_keys | join(', ') }}{% endif %}"
         - check: any_of
-          message: "Support_data variable must have LABLAXIS or LABL_PTR_1"
+          message: "{% if valid %}Support_data variable has LABLAXIS or LABL_PTR_1{% else %}Support_data variable must have LABLAXIS or LABL_PTR_1{% endif %}"
           assertions:
             - path: "variables/{var}/attributes/LABLAXIS"
               check: exists
@@ -41,7 +41,7 @@ assertions:
               - CDFEPOCH16
           then:
             check: any_of
-            message: "Support_data variable must have FORMAT or FORM_PTR"
+            message: "{% if valid %}Support_data variable has FORMAT or FORM_PTR{% else %}Support_data variable must have FORMAT or FORM_PTR{% endif %}"
             assertions:
               - path: "variables/{var}/attributes/FORMAT"
                 check: exists
@@ -60,7 +60,7 @@ assertions:
               - CDFEPOCH16
           then:
             check: any_of
-            message: "Support_data variable must have UNITS or UNIT_PTR"
+            message: "{% if valid %}Support_data variable has UNITS or UNIT_PTR{% else %}Support_data variable must have UNITS or UNIT_PTR{% endif %}"
             assertions:
               - path: "variables/{var}/attributes/UNITS"
                 check: exists

--- a/tests/test_positive_pass_messages.py
+++ b/tests/test_positive_pass_messages.py
@@ -1,0 +1,133 @@
+"""Passing validation leaves must read as positive statements, not as the failure
+phrasing of the rule. Reproducer for the "✔ … cannot be empty" / "✔ … must follow"
+oddity: rule messages without an ``{% if valid %}`` branch render their failure text
+verbatim on a passing line."""
+
+from astralint.base import Severity, ValidationResult, get_suite
+from astralint.base.file import Attribute, DataType, File, Variable
+
+# Failure-phrasing tells that must never appear on a passing leaf.
+_FAILURE_TELLS = (
+    "cannot be empty",
+    "must follow",
+    "must have",
+    "must be",
+    "must use",
+    "should use",
+    "should follow",
+    "does not",
+)
+
+
+def _attr(name: str, value: str) -> Attribute:
+    return Attribute(name=name, data_type=[DataType.CHAR], shape=[1], values=[value])
+
+
+def _file(global_attrs: dict[str, str], variables: dict[str, Variable] | None = None) -> File:
+    return File(
+        extension="cdf",
+        filename="x.cdf",
+        compression="NONE",
+        attributes={k: _attr(k, v) for k, v in global_attrs.items()},
+        variables=variables or {},
+    )
+
+
+def _rule(name: str):
+    suite = get_suite("ISTP")
+    assert suite is not None
+    return next(r for r in suite.rules if r.name == name)
+
+
+def _leaves(node):
+    if isinstance(node, ValidationResult):
+        yield node
+    else:
+        for child in node.results:
+            yield from _leaves(child)
+
+
+def _passing_messages(group) -> list[str]:
+    return [
+        leaf.message for leaf in _leaves(group) if leaf.valid and leaf.severity != Severity.SKIPPED
+    ]
+
+
+def _assert_no_failure_phrasing(rule_name: str, messages: list[str]) -> None:
+    assert messages, f"{rule_name}: expected at least one passing leaf"
+    for message in messages:
+        tell = next((t for t in _FAILURE_TELLS if t in message), None)
+        assert tell is None, f"{rule_name}: failure phrasing on a passing leaf: {message!r}"
+
+
+def test_global_attribute_rules_read_positively_on_pass():
+    file = _file(
+        {
+            "Data_type": "L2-Summary>level 2 summary",
+            "Project": "ISTP>International Solar-Terrestrial Physics",
+            "Descriptor": "EPI>Energetic Particles",
+            "Source_name": "GEOTAIL>Geomagnetic Tail",
+            "Data_version": "1.0",
+            "Logical_source": "geotail_epi_h0",
+            "Logical_file_id": "geotail_epi_h0_20200101_v01",
+            "TEXT": "Example dataset description.",
+            "Generation_date": "20200101",
+            "Instrument_type": "Particles (space)",
+            "DOI": "https://doi.org/10.1000/abc",
+        }
+    )
+    for rule_name in (
+        "DataTypeFormat",
+        "ProjectFormat",
+        "DescriptorFormat",
+        "SourceNameFormat",
+        "DataVersionFormat",
+        "LogicalSourceFormat",
+        "LogicalFileIdFormat",
+        "TextNotEmpty",
+        "GenerationDateFormat",
+        "InstrumentTypeValues",
+        "DOIFormat",
+    ):
+        _assert_no_failure_phrasing(rule_name, _passing_messages(_rule(rule_name).check(file)))
+
+
+def test_link_count_consistency_reads_positively_on_pass():
+    file = _file(
+        {
+            "HTTP_LINK": "http://example.org",
+            "LINK_TEXT": "example",
+            "LINK_TITLE": "Example",
+        }
+    )
+    _assert_no_failure_phrasing(
+        "LinkCountConsistency", _passing_messages(_rule("LinkCountConsistency").check(file))
+    )
+
+
+def _data_var() -> Variable:
+    keys = ["VAR_TYPE", "DEPEND_0", "DISPLAY_TYPE", "VALIDMIN", "VALIDMAX", "LABLAXIS", "UNITS"]
+    attrs = {k: _attr(k, "data" if k == "VAR_TYPE" else "x") for k in keys}
+    return Variable(
+        name="Bx",
+        attributes=attrs,
+        compression="NONE",
+        data_type=DataType.FLOAT32,
+        record_variance=True,
+        shape=[10],
+    )
+
+
+def test_data_variable_member_messages_read_positively_on_pass():
+    group = _rule("DataVariableAttributes").check(_file({}, {"Bx": _data_var()}))
+    messages = _passing_messages(group)
+    _assert_no_failure_phrasing("DataVariableAttributes", messages)
+    assert any("has LABLAXIS or LABL_PTR_1" in m for m in messages)
+    assert any("has UNITS or UNIT_PTR" in m for m in messages)
+
+
+def test_positive_phrasings_are_specific():
+    file = _file({"Data_type": "L2-Summary>level 2 summary"})
+    messages = _passing_messages(_rule("DataTypeFormat").check(file))
+    assert any("Data_type follows" in m for m in messages)
+    assert any("Data_type is present" in m for m in messages)


### PR DESCRIPTION
Follow-up to #45. **Stacked on #45 — merge that first.** The net change here is the single commit `fix(rules): give passing ISTP rule messages positive phrasing`; the other commits belong to #45 and will drop out of this diff once #45 merges.

## Summary

After #45 made passing rules render their per-member detail, some passing lines read oddly because the rule's `message:` only had failure phrasing — e.g. `✔ ISTP-GA-006: Data_type cannot be empty`, `✔ ISTP-VA-002: Data variable must have UNITS or UNIT_PTR`.

This adds an `{% if valid %}…{% else %}…{% endif %}` branch to the 26 affected ISTP messages so a passing check reads as a positive statement, while the failure (else) text is preserved **verbatim**. So failing output — and the leaves the resolver routes auto-fixes on — are unchanged.

Examples (passing line, before → after):
- `Data_type cannot be empty` → `Data_type is present`
- `Data_type must follow format: ABBREV>Full_description …` → `Data_type follows the ABBREV>Full_description format`
- `Data variable must have LABLAXIS or LABL_PTR_1` → `Data variable has LABLAXIS or LABL_PTR_1`
- `HTTP_LINK and LINK_TEXT must have the same number of entries` → `… have the same number of entries`
- `Instrument_type should use a standard ISTP value` → `Instrument_type uses a standard ISTP value`

15 rule files, 26 messages (matches / not_empty / in / comparison / compare_to / exists-in-any_of — all verified to pass `valid` into the message context).

## Test plan

- [x] New reproducer `tests/test_positive_pass_messages.py` (failing before, passing after): passing leaves of the affected rules contain no failure-phrasing tells, and specific positive phrasings render
- [x] `uv run pytest` — 391 passed
- [x] `make lint` — clean
- [x] #45's failing-leaf invariance guard still green (failure text byte-identical)
- [x] Verified the rendered console `--show-passed` output on the MMS resource CDF reads positively

🤖 Generated with [Claude Code](https://claude.com/claude-code)