### PR TITLE
Web report: default to failures-only + auto-rerun on suite change

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -914,6 +914,15 @@ validate_file_url(file_url, selected_suite)
             }
         }
 
+        // Re-validate the file already loaded, against the currently-checked suite.
+        // Wired to the suite radios so changing the suite re-runs analysis without a
+        // re-upload; a no-op until a file has been loaded.
+        function revalidateCurrent() {
+            if (!pyodide) return;
+            if (lastBytes) { validateBytes(lastBytes, lastName); }
+            else if (lastUrl) { processFileFromUrl(lastUrl); }
+        }
+
         // Deep-link support: ?url=<file>&suite=<SUITE> prefills and auto-validates.
         // Lets other tools (e.g. the CDFpp WASM demo) hand a CDF off to AstraLint.
         function autoRunFromQuery() {
@@ -999,6 +1008,11 @@ validate_file_url(file_url, selected_suite)
                 if (e.key === 'Enter' && pyodide) {
                     processFileFromUrl(urlInput.value);
                 }
+            });
+
+            // Changing the suite re-runs the analysis on the loaded file automatically.
+            document.querySelectorAll('input[name="suite"]').forEach((radio) => {
+                radio.addEventListener('change', revalidateCurrent);
             });
 
             // Accept a CDF handed off via postMessage (e.g. from the CDFpp WASM demo

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -731,27 +731,28 @@ def validate_file_url(url: str, suite_name: str = "ISTP") -> str:
             });
 
             const filterInput = document.getElementById('alr-filter');
-            const failedOnly = document.getElementById('alr-failed-only');
-            if (!filterInput || !failedOnly) return;
+            const showPassed = document.getElementById('alr-show-passed');
+            if (!filterInput || !showPassed) return;
 
             function applyFilter() {
                 const q = filterInput.value.toLowerCase();
-                const onlyFailed = failedOnly.checked;
+                const show = showPassed.checked;
                 document.querySelectorAll('.alr .result').forEach(r => {
                     const matchesText = !q || r.textContent.toLowerCase().includes(q);
-                    const matchesState = !onlyFailed || r.classList.contains('invalid');
+                    const matchesState = show || r.classList.contains('invalid');
                     r.style.display = (matchesText && matchesState) ? '' : 'none';
                 });
                 document.querySelectorAll('.alr .group').forEach(g => {
                     const visible = [...g.querySelectorAll('.result')]
                         .some(r => r.style.display !== 'none');
                     g.style.display = visible ? '' : 'none';
-                    if (visible && (q || onlyFailed)) g.classList.remove('collapsed');
+                    if (visible && (q || !show)) g.classList.remove('collapsed');
                 });
             }
 
             filterInput.addEventListener('input', applyFilter);
-            failedOnly.addEventListener('change', applyFilter);
+            showPassed.addEventListener('change', applyFilter);
+            applyFilter();  // default view: failures only (tick "Show passed" to reveal the rest)
         }
 
         // Trigger a browser download of base64-encoded bytes.

--- a/src/astralint/reports/html.py
+++ b/src/astralint/reports/html.py
@@ -256,7 +256,7 @@ _REPORT_BODY = """
         <div class="filter-bar">
             <input type="search" id="alr-filter" placeholder="Filter results by text…" autocomplete="off">
             <label class="failed-toggle">
-                <input type="checkbox" id="alr-failed-only"> Show only failed
+                <input type="checkbox" id="alr-show-passed"> Show passed
             </label>
         </div>
 
@@ -278,22 +278,23 @@ _REPORT_BODY = """
 
         function applyFilter() {
             const q = document.getElementById('alr-filter').value.toLowerCase();
-            const failedOnly = document.getElementById('alr-failed-only').checked;
+            const showPassed = document.getElementById('alr-show-passed').checked;
             document.querySelectorAll('.alr .result').forEach(r => {
                 const matchesText = !q || r.textContent.toLowerCase().includes(q);
-                const matchesState = !failedOnly || r.classList.contains('invalid');
+                const matchesState = showPassed || r.classList.contains('invalid');
                 r.style.display = (matchesText && matchesState) ? '' : 'none';
             });
             document.querySelectorAll('.alr .group').forEach(g => {
                 const visible = [...g.querySelectorAll('.result')]
                     .some(r => r.style.display !== 'none');
                 g.style.display = visible ? '' : 'none';
-                if (visible && (q || failedOnly)) g.classList.remove('collapsed');
+                if (visible && (q || !showPassed)) g.classList.remove('collapsed');
             });
         }
 
         document.getElementById('alr-filter').addEventListener('input', applyFilter);
-        document.getElementById('alr-failed-only').addEventListener('change', applyFilter);
+        document.getElementById('alr-show-passed').addEventListener('change', applyFilter);
+        applyFilter();  // default view: failures only (tick "Show passed" to reveal the rest)
     </script>
 """
 

--- a/tests/test_report_ergonomics.py
+++ b/tests/test_report_ergonomics.py
@@ -218,10 +218,17 @@ class TestHtmlFilterBox:
         html = generate_html(self._group())
         assert 'id="alr-filter"' in html
 
-    def test_html_has_failed_only_toggle(self):
+    def test_html_has_show_passed_toggle(self):
         html = generate_html(self._group())
-        assert 'id="alr-failed-only"' in html
+        assert 'id="alr-show-passed"' in html
+        assert "Show passed" in html
 
     def test_html_filter_script_present(self):
         html = generate_html(self._group())
         assert "applyFilter" in html
+
+    def test_html_defaults_to_failures_only(self):
+        # The filter runs on load so the report opens showing failures only;
+        # ticking "Show passed" reveals the rest.
+        html = generate_html(self._group())
+        assert "applyFilter();" in html


### PR DESCRIPTION
Two small web-UI improvements to the HTML report and the demo.

## Summary

- **Default the report to failures-only.** The HTML report (and the demo) now open showing only failed results; the filter runs on load. The toggle is relabelled **"Show passed"** (opt-in) to reveal passing/info results, matching the existing `--show-passed` terminology. Applies to both the standalone `astralint lint --output html` report and the demo's re-wired handler.
- **Auto-rerun on suite change (demo).** Changing the conformance suite re-validates the already-loaded file (bytes or URL) automatically — no re-upload. No-op until a file is loaded.

## Test plan

- [x] `uv run pytest` green; `make lint` clean
- [x] Browser-verified the report opens with 0 passing / N failing visible; ticking "Show passed" reveals all passing
- [x] Browser-verified (stubbed) that a suite change re-runs on the loaded bytes / re-loads the URL / no-ops when nothing is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)