### PR TITLE
feat(PDS4): complete CDF-A structural rules — version, contiguity, zVariables

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,21 +334,14 @@ assertions:
 
 - **ISTP** - [ISTP Metadata Guidelines](https://istp-metadata.readthedocs.io/)
 - **CDAWeb** - [CDAWeb](https://cdaweb.gsfc.nasa.gov/) ingestion profile: inherits ISTP and promotes the CDAWeb-required attributes (`Instrument_type`, `Mission_group`) to errors, plus CDAWeb-specific entry limits
-- **PDS4** - PDS4 CDF archiving profile (CDF-A): inherits ISTP and adds the constraints from the [Guide to Archiving CDF Files in PDS4](https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf) — no file/variable compression, CDF version ≥ 3.4, and a required `spase_DatasetResourceID`. Two remaining structural requirements (contiguous variables, zVariables-only) await pycdfpp support; see the codec backlog below.
+- **PDS4** - PDS4 CDF archiving profile (CDF-A): inherits ISTP and adds the constraints from the [Guide to Archiving CDF Files in PDS4](https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf) — no file/variable compression, CDF version ≥ 3.4, a required `spase_DatasetResourceID`, contiguous (non-fragmented) variables, and zVariables only.
 - **SOLARNET** - [SOLARNET Metadata Recommendations](https://solarnet.readthedocs.io/en/stable/index.html)
 
-### PDS4 codec backlog
-
-Of the CDF-A structural requirements, two cannot yet be checked because **pycdfpp does not
-expose** the needed information (verified against pycdfpp 0.10.0). Implementing them means
-adding bindings upstream in [pycdfpp](https://github.com/SciQLop/pycdfpp), surfacing the flags
-on the `Variable` model, then adding `PDS4-CDFA-004/005` rules:
-
-- **Contiguous (non-fragmented) variables** — pycdfpp abstracts the physical VVR layout away on read.
-- **zVariables only** (no rVariables) — pycdfpp exposes no r/z distinction.
-
-The *single-file* requirement is satisfied by construction: AstraLint only loads single-file
-CDFs. (See [issue #2](https://github.com/SciQLop/AstraLint/issues/2).)
+The PDS4 suite covers every CDF-A structural requirement that applies. Contiguity and
+zVariable-only checks use `Variable.is_contiguous` / `is_zvariable` from
+[pycdfpp](https://github.com/SciQLop/pycdfpp) ≥ 0.11 (older pycdfpp simply skips those two
+checks). The *single-file* requirement is satisfied by construction — AstraLint only loads
+single-file CDFs. (See [issue #2](https://github.com/SciQLop/AstraLint/issues/2).)
 
 ## Extending AstraLint
 

--- a/README.md
+++ b/README.md
@@ -334,21 +334,21 @@ assertions:
 
 - **ISTP** - [ISTP Metadata Guidelines](https://istp-metadata.readthedocs.io/)
 - **CDAWeb** - [CDAWeb](https://cdaweb.gsfc.nasa.gov/) ingestion profile: inherits ISTP and promotes the CDAWeb-required attributes (`Instrument_type`, `Mission_group`) to errors, plus CDAWeb-specific entry limits
-- **PDS4** - PDS4 CDF archiving profile (CDF-A): inherits ISTP and adds the constraints from the [Guide to Archiving CDF Files in PDS4](https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf) — no file/variable compression, and a required `spase_DatasetResourceID`. Four further structural requirements (CDF version ≥ 3.4, single-file, contiguous variables, zVariables-only) are not yet checked because the `File` model does not carry that information; see the codec backlog below.
+- **PDS4** - PDS4 CDF archiving profile (CDF-A): inherits ISTP and adds the constraints from the [Guide to Archiving CDF Files in PDS4](https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf) — no file/variable compression, CDF version ≥ 3.4, and a required `spase_DatasetResourceID`. Two remaining structural requirements (contiguous variables, zVariables-only) await pycdfpp support; see the codec backlog below.
 - **SOLARNET** - [SOLARNET Metadata Recommendations](https://solarnet.readthedocs.io/en/stable/index.html)
 
 ### PDS4 codec backlog
 
-The CDF-A specification lists structural requirements that AstraLint cannot yet check
-because the `File`/`Variable` model does not capture them. Implementing these means
-extending the CDF codec and model, then adding the corresponding `PDS4-CDFA-003..006` rules:
+Of the CDF-A structural requirements, two cannot yet be checked because **pycdfpp does not
+expose** the needed information (verified against pycdfpp 0.10.0). Implementing them means
+adding bindings upstream in [pycdfpp](https://github.com/SciQLop/pycdfpp), surfacing the flags
+on the `Variable` model, then adding `PDS4-CDFA-004/005` rules:
 
-- **CDF version ≥ 3.4** — needs `File.cdf_version`.
-- **Single-file CDF** (not multi-file) — needs `File.is_single_file`.
-- **Contiguous (non-fragmented) variables** — needs a per-variable fragmentation flag.
-- **zVariables only** (no rVariables) — needs a per-variable `is_zvariable` flag.
+- **Contiguous (non-fragmented) variables** — pycdfpp abstracts the physical VVR layout away on read.
+- **zVariables only** (no rVariables) — pycdfpp exposes no r/z distinction.
 
-(See [issue #2](https://github.com/SciQLop/AstraLint/issues/2).)
+The *single-file* requirement is satisfied by construction: AstraLint only loads single-file
+CDFs. (See [issue #2](https://github.com/SciQLop/AstraLint/issues/2).)
 
 ## Extending AstraLint
 

--- a/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
+++ b/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
@@ -49,7 +49,8 @@ but **not** CDF version, single-vs-multi-file, fragmentation, or zVariable-vs-rV
 | `PDS4-GA-002` `spase_DatasetResourceID` format  | CDF-A          | ERROR    | ✅ `matches ^spase://[^/]+/.+$` |
 | `PDS4-GA-003` recommended SPASE attrs    | CDF-A optional      | INFO     | ✅ `contains_keys` (not required) |
 | `PDS4-CDFA-003` CDF version ≥ 3.4        | structural #1       | ERROR    | ✅ `format_version` + `version_at_least` |
-| contiguity / zVariables only             | structural #4,5     | —        | ❌ pycdfpp 0.10 doesn't expose it |
+| `PDS4-CDFA-004` no fragmented variables  | structural #4       | ERROR    | ✅ `variables/.*/is_contiguous` + `is_true` (pycdfpp ≥ 0.11) |
+| `PDS4-CDFA-005` zVariables only          | structural #5       | ERROR    | ✅ `variables/.*/is_zvariable` + `is_true` (pycdfpp ≥ 0.11) |
 | single-file                              | structural #2       | —        | ✅ satisfied by construction (loader is single-file only) |
 
 Compression surfaces as the pycdfpp `CompressionType` enum name — `no_compression` vs
@@ -81,17 +82,19 @@ branches (project convention since the readable-passing-rules work).
 
 ## Structural constraints — resolution
 
-After inspecting pycdfpp 0.10.0:
+All four representable CDF-A structural constraints are now checked:
 
-- **#1 version ≥ 3.4** — implemented. pycdfpp exposes `cdf.distribution_version` (a tuple);
-  the codec formats it onto `File.format_version` ("3.5.0") and a new `version_at_least`
-  assertion compares it numerically per component (so `3.10 > 3.9`, unlike a regex or string
-  compare). Rule `PDS4-CDFA-003`.
+- **#1 version ≥ 3.4** — `cdf.distribution_version` (a tuple) → `File.format_version`
+  ("3.5.0"); the `version_at_least` assertion compares numerically per component (so
+  `3.10 > 3.9`). Rule `PDS4-CDFA-003`.
 - **#2 single-file** — satisfied by construction: AstraLint/pycdfpp only load single-file
-  CDFs, so any validated file is single-file. No rule needed.
-- **#4 contiguity / #5 zVariables** — pycdfpp does not surface the physical VVR layout or any
-  r/z distinction. These need new bindings upstream in pycdfpp, then a per-`Variable` flag and
-  `PDS4-CDFA-004/005`. Remaining backlog (issue #2).
+  CDFs. No rule needed.
+- **#4 contiguity / #5 zVariables** — pycdfpp **0.11.0** added `Variable.is_contiguous()`
+  (method) and `Variable.is_zvariable` (property). The codec maps both onto the `Variable`
+  model (`getattr` fallback → `None` when an older pycdfpp is present); a new `is_true`
+  assertion checks them per variable (True→pass, False→fail, None→not-applicable). Rules
+  `PDS4-CDFA-004` (no fragmented variables) and `PDS4-CDFA-005` (zVariables only). Floor
+  bumped to `pycdfpp>=0.11.0` (safe — 0.11.0 ships both Pyodide-ABI emscripten wheels).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
+++ b/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
@@ -48,7 +48,9 @@ but **not** CDF version, single-vs-multi-file, fragmentation, or zVariable-vs-rV
 | `PDS4-GA-001` `spase_DatasetResourceID` present | CDF-A required | ERROR    | ✅ `contains_keys` on `attributes` |
 | `PDS4-GA-002` `spase_DatasetResourceID` format  | CDF-A          | ERROR    | ✅ `matches ^spase://[^/]+/.+$` |
 | `PDS4-GA-003` recommended SPASE attrs    | CDF-A optional      | INFO     | ✅ `contains_keys` (not required) |
-| version / single-file / contiguity / zVar | structural #1,2,4,5 | —      | ❌ needs codec + model fields |
+| `PDS4-CDFA-003` CDF version ≥ 3.4        | structural #1       | ERROR    | ✅ `format_version` + `version_at_least` |
+| contiguity / zVariables only             | structural #4,5     | —        | ❌ pycdfpp 0.10 doesn't expose it |
+| single-file                              | structural #2       | —        | ✅ satisfied by construction (loader is single-file only) |
 
 Compression surfaces as the pycdfpp `CompressionType` enum name — `no_compression` vs
 `gzip_compression`/etc. — at the `File` root and on each `Variable`.
@@ -60,6 +62,7 @@ mirroring ISTP layout):
 
 - `Structural/NoFileCompression.yaml`        → `PDS4-CDFA-001` (ERROR)
 - `Structural/NoVariableCompression.yaml`    → `PDS4-CDFA-002` (ERROR, per-variable)
+- `Structural/CdfVersion.yaml`               → `PDS4-CDFA-003` (ERROR; `version_at_least` on `File.format_version`)
 - `GlobalAttributes/SpaseDatasetResourceIdRequired.yaml` → `PDS4-GA-001` (ERROR)
 - `GlobalAttributes/SpaseDatasetResourceIdFormat.yaml`   → `PDS4-GA-002` (ERROR)
 - `GlobalAttributes/RecommendedSpaseAttributes.yaml`     → `PDS4-GA-003` (INFO)
@@ -76,13 +79,19 @@ branches (project convention since the readable-passing-rules work).
   compression) is a real future resolver entry but is out of scope here.
   `spase_DatasetResourceID` stays USER-only — never fabricated (identity/provenance).
 
-## Backlog: structural constraints needing a codec/model extension
+## Structural constraints — resolution
 
-The four structural constraints (#1 version, #2 single-file, #4 contiguity, #5 zVariables)
-are real PDS4 requirements but are not representable in the current `File` model. They are
-documented as a follow-up: extend the CDF codec + `File`/`Variable` models to carry
-`cdf_version`, `is_single_file`, per-variable `is_zvariable`, and a contiguity/fragmentation
-flag, then add `PDS4-CDFA-003..006`. Tracked in the README/PDS4 docs and issue #2.
+After inspecting pycdfpp 0.10.0:
+
+- **#1 version ≥ 3.4** — implemented. pycdfpp exposes `cdf.distribution_version` (a tuple);
+  the codec formats it onto `File.format_version` ("3.5.0") and a new `version_at_least`
+  assertion compares it numerically per component (so `3.10 > 3.9`, unlike a regex or string
+  compare). Rule `PDS4-CDFA-003`.
+- **#2 single-file** — satisfied by construction: AstraLint/pycdfpp only load single-file
+  CDFs, so any validated file is single-file. No rule needed.
+- **#4 contiguity / #5 zVariables** — pycdfpp does not surface the physical VVR layout or any
+  r/z distinction. These need new bindings upstream in pycdfpp, then a per-`Variable` flag and
+  `PDS4-CDFA-004/005`. Remaining backlog (issue #2).
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
     "astropy>=7.2.0; sys_platform != 'emscripten'",
     "cyclopts>=4.5.2",
     "jinja2>=3.1.0",
-    "pycdfpp>=0.8.5",
+    # 0.11.0 adds Variable.is_zvariable / is_contiguous (PDS4-CDFA-004/005) and ships
+    # emscripten wheels for both Pyodide ABIs (cp313/2025_0 + cp314/2026_0).
+    "pycdfpp>=0.11.0",
     "pydantic>=2.12.5",
     "pyyaml>=6.0",
     "requests>=2.32.5",

--- a/src/astralint/base/file.py
+++ b/src/astralint/base/file.py
@@ -36,6 +36,9 @@ class Variable(BaseModel):
     data_type: DataType
     record_variance: bool
     shape: list[int]
+    # Physical-layout facts the codec may expose; None when unknown.
+    is_zvariable: bool | None = None  # False = legacy rVariable
+    is_contiguous: bool | None = None  # False = record data fragmented across the file
 
 
 class File(BaseModel):

--- a/src/astralint/base/file.py
+++ b/src/astralint/base/file.py
@@ -44,3 +44,6 @@ class File(BaseModel):
     compression: str
     attributes: dict[str, Attribute]
     variables: dict[str, Variable]
+    # Format-spec version of the source file, "major.minor.patch" (e.g. CDF "3.5.0").
+    # None when the codec does not expose one (e.g. FITS).
+    format_version: str | None = None

--- a/src/astralint/base/yaml_rules/assertions/__init__.py
+++ b/src/astralint/base/yaml_rules/assertions/__init__.py
@@ -18,6 +18,7 @@ from .exists import ExistsAssertion, NotExistsAssertion
 from .is_type import IsTypeAssertion
 from .matches import MatchesAssertion
 from .relationship import ReferencesVariableAssertion
+from .version import VersionAtLeastAssertion
 
 __all__ = [
     "ContainsKeysAssertion",
@@ -43,4 +44,5 @@ __all__ = [
     "LengthAssertion",
     "NotEmptyAssertion",
     "ReferencesVariableAssertion",
+    "VersionAtLeastAssertion",
 ]

--- a/src/astralint/base/yaml_rules/assertions/__init__.py
+++ b/src/astralint/base/yaml_rules/assertions/__init__.py
@@ -1,3 +1,4 @@
+from .boolean import IsTrueAssertion
 from .collections import ContainsAssertion, LengthAssertion, NotContainsAssertion, NotEmptyAssertion
 from .combinations import (
     AllOf,
@@ -45,4 +46,5 @@ __all__ = [
     "NotEmptyAssertion",
     "ReferencesVariableAssertion",
     "VersionAtLeastAssertion",
+    "IsTrueAssertion",
 ]

--- a/src/astralint/base/yaml_rules/assertions/boolean.py
+++ b/src/astralint/base/yaml_rules/assertions/boolean.py
@@ -1,0 +1,48 @@
+from typing import Literal
+
+from pydantic import ConfigDict
+
+from ...file import File
+from ...validation_result import Severity, ValidationResult
+from .base import BaseAssertion, build_context, clean_target, render_message
+
+
+class IsTrueAssertion(BaseAssertion):
+    """A boolean value must be True.
+
+    False fails; None is treated as not applicable and passes (e.g. a codec that
+    does not expose the flag). Used for structural facts like a variable being a
+    zVariable or its records being contiguous.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    check: Literal["is_true"] = "is_true"  # type: ignore[assignment]
+
+    _default_template: str = (
+        "{% if valid %}condition holds{% else %}condition does not hold{% endif %}"
+    )
+
+    def single_assertion(
+        self,
+        file: File,
+        path: str,
+        value: object,
+        severity: Severity,
+        captures: dict[str, str] | None = None,
+    ) -> ValidationResult:
+        target = clean_target(path)
+
+        if value is None:
+            return ValidationResult(
+                valid=True, reference="", severity=severity, message="", target=target
+            )
+
+        passed = value is True
+        ctx = build_context(target, path, value, valid=passed, **(captures or {}))
+        return ValidationResult(
+            valid=passed,
+            reference="",
+            severity=severity,
+            message=render_message(self.message or self._default_template, ctx),
+            target=target,
+        )

--- a/src/astralint/base/yaml_rules/assertions/version.py
+++ b/src/astralint/base/yaml_rules/assertions/version.py
@@ -1,0 +1,65 @@
+from typing import Literal
+
+from pydantic import ConfigDict
+
+from ...file import File
+from ...validation_result import Severity, ValidationResult
+from .base import BaseAssertion, build_context, clean_target, render_message
+
+
+def _parse(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def _at_least(value: tuple[int, ...], minimum: tuple[int, ...]) -> bool:
+    length = max(len(value), len(minimum))
+    pad = lambda v: v + (0,) * (length - len(v))  # noqa: E731
+    return pad(value) >= pad(minimum)
+
+
+class VersionAtLeastAssertion(BaseAssertion):
+    """A dotted version string (major.minor.patch) must be >= a minimum.
+
+    Compares numerically per component (so '3.10' > '3.9'), unlike a regex or a
+    lexicographic string comparison. A None/absent value is treated as not
+    applicable and passes (e.g. a codec that exposes no version).
+    """
+
+    model_config = ConfigDict(frozen=True)
+    check: Literal["version_at_least"] = "version_at_least"  # type: ignore[assignment]
+    minimum: str
+
+    _default_template: str = "{% if valid %}version {{ value }} is at least {{ minimum }}{% else %}version {{ value }} is older than the required minimum {{ minimum }}{% endif %}"
+    _unparseable_template: str = "could not parse version {{ value }}"
+
+    def single_assertion(
+        self,
+        file: File,
+        path: str,
+        value: object,
+        severity: Severity,
+        captures: dict[str, str] | None = None,
+    ) -> ValidationResult:
+        target = clean_target(path)
+        extra = {"minimum": self.minimum, **(captures or {})}
+
+        if value is None:
+            return ValidationResult(
+                valid=True, reference="", severity=severity, message="", target=target
+            )
+
+        try:
+            passed = _at_least(_parse(str(value)), _parse(self.minimum))
+            template = self.message or self._default_template
+        except ValueError:
+            passed = False
+            template = self._unparseable_template
+
+        ctx = build_context(target, path, value, valid=passed, **extra)
+        return ValidationResult(
+            valid=passed,
+            reference="",
+            severity=severity,
+            message=render_message(template, ctx),
+            target=target,
+        )

--- a/src/astralint/codecs/cdf.py
+++ b/src/astralint/codecs/cdf.py
@@ -41,6 +41,12 @@ def _to_data_type(cdf_dtype: CDFDataType) -> DataType:
     return type_mapping.get(cdf_dtype, DataType.NONE)
 
 
+def _format_version(cdf) -> str | None:
+    """The CDF spec version as 'major.minor.patch' (pycdfpp exposes a tuple)."""
+    version = getattr(cdf, "distribution_version", None)
+    return ".".join(str(part) for part in version) if version else None
+
+
 def _compression_name(item) -> str:
     """The compression type name, tolerating an unknown CompressionType code.
 
@@ -113,6 +119,7 @@ class CdfCodec(Codec):
                 extension="cdf",
                 filename=fname,
                 compression=_compression_name(cdf),
+                format_version=_format_version(cdf),
                 attributes={name: _parse_attribute(attr) for name, attr in cdf.attributes.items()},
                 variables={name: _parse_variable(var) for name, var in cdf.items()},
             )

--- a/src/astralint/codecs/cdf.py
+++ b/src/astralint/codecs/cdf.py
@@ -87,6 +87,16 @@ def _(attr: CDFVariableAttribute) -> Attribute:
     )
 
 
+def _is_contiguous(var) -> bool | None:
+    """Whether the variable's record data is a single contiguous block.
+
+    pycdfpp >= 0.11 exposes this as a method; older versions don't expose it at all
+    (then it stays None — not applicable).
+    """
+    method = getattr(var, "is_contiguous", None)
+    return bool(method()) if callable(method) else None
+
+
 def _parse_variable(var: CDFVariable) -> Variable:
     return Variable(
         name=var.name,
@@ -95,6 +105,8 @@ def _parse_variable(var: CDFVariable) -> Variable:
         compression=_compression_name(var),
         record_variance=not var.is_nrv,
         data_type=_to_data_type(var.type),
+        is_zvariable=getattr(var, "is_zvariable", None),
+        is_contiguous=_is_contiguous(var),
     )
 
 

--- a/src/astralint/suites/PDS4/rules/Structural/CdfVersion.yaml
+++ b/src/astralint/suites/PDS4/rules/Structural/CdfVersion.yaml
@@ -1,0 +1,13 @@
+name: CdfVersion
+description: "A PDS4-archivable CDF must be written with CDF version 3.4 or later (CDF-A)"
+url: "https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf"
+reference: "PDS4-CDFA-003"
+severity: ERROR
+suite: PDS4
+
+assertions:
+  # "Requirements for Archivable CDF files" #1: Create CDF compliant with version 3.4 or later.
+  - path: "format_version"
+    check: version_at_least
+    minimum: "3.4"
+    message: "{% if valid %}the CDF was written with version {{ value }} (>= 3.4){% else %}PDS4 archiving requires CDF version 3.4 or later; this file is version {{ value }}{% endif %}"

--- a/src/astralint/suites/PDS4/rules/Structural/NoFragmentedVariables.yaml
+++ b/src/astralint/suites/PDS4/rules/Structural/NoFragmentedVariables.yaml
@@ -1,0 +1,13 @@
+name: NoFragmentedVariables
+description: "A PDS4-archivable CDF must store each variable's data contiguously (CDF-A)"
+url: "https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf"
+reference: "PDS4-CDFA-004"
+severity: ERROR
+suite: PDS4
+
+assertions:
+  # "Requirements for Archivable CDF files" #4: No fragmented variables (all data for a
+  # variable must be contiguous in the file). Re-save with cdfconvert to defragment.
+  - path: "variables/.*/is_contiguous"
+    check: is_true
+    message: "{% if valid %}{{ variable }} is stored contiguously{% else %}PDS4 archiving forbids fragmented variables; {{ variable }} is fragmented (records written across multiple blocks). Re-save with cdfconvert to defragment{% endif %}"

--- a/src/astralint/suites/PDS4/rules/Structural/ZVariablesOnly.yaml
+++ b/src/astralint/suites/PDS4/rules/Structural/ZVariablesOnly.yaml
@@ -1,0 +1,12 @@
+name: ZVariablesOnly
+description: "A PDS4-archivable CDF must use only zVariables, not legacy rVariables (CDF-A)"
+url: "https://pds.nasa.gov/datastandards/documents/archiving/Guide-to-Archiving-CDF-Files-in-PDS4-v7.pdf"
+reference: "PDS4-CDFA-005"
+severity: ERROR
+suite: PDS4
+
+assertions:
+  # "Requirements for Archivable CDF files" #5: Use only zVariables.
+  - path: "variables/.*/is_zvariable"
+    check: is_true
+    message: "{% if valid %}{{ variable }} is a zVariable{% else %}PDS4 archiving requires zVariables only; {{ variable }} is a legacy rVariable{% endif %}"

--- a/tests/test_pds4_suite.py
+++ b/tests/test_pds4_suite.py
@@ -27,6 +27,7 @@ def attr(name: str, values: list) -> Attribute:
 def make_file(
     *,
     compression: str = "no_compression",
+    format_version: str | None = "3.5.0",
     global_attrs: dict | None = None,
     variables: dict | None = None,
 ) -> File:
@@ -34,6 +35,7 @@ def make_file(
         extension="cdf",
         filename="test.cdf",
         compression=compression,
+        format_version=format_version,
         attributes=global_attrs or {},
         variables=variables or {},
     )
@@ -61,6 +63,7 @@ def test_pds4_inherits_all_istp_rules_and_adds_its_own():
     for ref in (
         "PDS4-CDFA-001",
         "PDS4-CDFA-002",
+        "PDS4-CDFA-003",
         "PDS4-GA-001",
         "PDS4-GA-002",
         "PDS4-GA-003",
@@ -89,6 +92,25 @@ def test_no_variable_compression_flags_compressed_variable():
     assert not rule.check(bad).valid
     good = make_file(variables={"v": make_var("v", compression="no_compression")})
     assert rule.check(good).valid
+
+
+def test_cdf_version_rule_requires_3_4_or_later():
+    rule = _rule("Structural/CdfVersion.yaml")
+    assert not rule.check(make_file(format_version="3.3.0")).valid
+    assert rule.check(make_file(format_version="3.4.0")).valid
+    assert rule.check(make_file(format_version="3.5.0")).valid
+    # numeric per-component comparison, not lexicographic: 3.10 > 3.4
+    assert rule.check(make_file(format_version="3.10.0")).valid
+    # absent version (e.g. non-CDF codec) is not applicable => passes
+    assert rule.check(make_file(format_version=None)).valid
+
+
+def test_real_resource_reports_its_cdf_version():
+    from astralint.codecs.cdf import CdfCodec
+
+    f = CdfCodec.load(str(RESOURCES / "mms1_asp2_srvy_l1b_stat_00000000_v01.cdf"))
+    assert f is not None and f.format_version == "3.5.0"
+    assert _rule("Structural/CdfVersion.yaml").check(f).valid
 
 
 def test_spase_dataset_resource_id_required():

--- a/tests/test_pds4_suite.py
+++ b/tests/test_pds4_suite.py
@@ -41,7 +41,13 @@ def make_file(
     )
 
 
-def make_var(name: str, *, compression: str = "no_compression") -> Variable:
+def make_var(
+    name: str,
+    *,
+    compression: str = "no_compression",
+    is_zvariable: bool | None = True,
+    is_contiguous: bool | None = True,
+) -> Variable:
     return Variable(
         name=name,
         attributes={},
@@ -49,6 +55,8 @@ def make_var(name: str, *, compression: str = "no_compression") -> Variable:
         data_type=DataType.FLOAT64,
         record_variance=True,
         shape=[1],
+        is_zvariable=is_zvariable,
+        is_contiguous=is_contiguous,
     )
 
 
@@ -64,11 +72,45 @@ def test_pds4_inherits_all_istp_rules_and_adds_its_own():
         "PDS4-CDFA-001",
         "PDS4-CDFA-002",
         "PDS4-CDFA-003",
+        "PDS4-CDFA-004",
+        "PDS4-CDFA-005",
         "PDS4-GA-001",
         "PDS4-GA-002",
         "PDS4-GA-003",
     ):
         assert ref in pds4_refs, f"PDS4 must add {ref}"
+
+
+def test_no_fragmented_variables_flags_fragmented():
+    rule = _rule("Structural/NoFragmentedVariables.yaml")
+    bad = make_file(variables={"v": make_var("v", is_contiguous=False)})
+    assert not rule.check(bad).valid
+    good = make_file(variables={"v": make_var("v", is_contiguous=True)})
+    assert rule.check(good).valid
+    # unknown (old pycdfpp) => not applicable, passes
+    unknown = make_file(variables={"v": make_var("v", is_contiguous=None)})
+    assert rule.check(unknown).valid
+
+
+def test_zvariables_only_flags_rvariable():
+    rule = _rule("Structural/ZVariablesOnly.yaml")
+    bad = make_file(variables={"v": make_var("v", is_zvariable=False)})
+    assert not rule.check(bad).valid
+    good = make_file(variables={"v": make_var("v", is_zvariable=True)})
+    assert rule.check(good).valid
+    unknown = make_file(variables={"v": make_var("v", is_zvariable=None)})
+    assert rule.check(unknown).valid
+
+
+def test_real_resource_is_all_z_and_contiguous():
+    from astralint.codecs.cdf import CdfCodec
+
+    f = CdfCodec.load(str(RESOURCES / "mms1_asp2_srvy_l1b_stat_00000000_v01.cdf"))
+    assert f is not None
+    assert all(v.is_zvariable for v in f.variables.values())
+    assert all(v.is_contiguous for v in f.variables.values())
+    assert _rule("Structural/ZVariablesOnly.yaml").check(f).valid
+    assert _rule("Structural/NoFragmentedVariables.yaml").check(f).valid
 
 
 def test_no_file_compression_flags_compressed_file():


### PR DESCRIPTION
## What

Completes the PDS4 / CDF-A **structural** rules. Two parts:

1. **Recovers `PDS4-CDFA-003` (CDF version ≥ 3.4)** — its commit was dropped when #49 was squash-merged from its first commit only, so `main` never got it. Re-applied here: `File.format_version` (codec-agnostic, from `cdf.distribution_version`) + a `version_at_least` assertion that compares dotted versions numerically per component (`3.10 > 3.9`).
2. **Adds `PDS4-CDFA-004` (no fragmented variables) and `PDS4-CDFA-005` (zVariables only)** — now reachable thanks to **pycdfpp 0.11.0**, which exposes `Variable.is_contiguous()` and `Variable.is_zvariable`.

## How

- CDF codec maps `is_zvariable` / `is_contiguous` onto the `Variable` model, with a `getattr` fallback to `None` when an older pycdfpp is present.
- New `is_true` assertion: `True` → pass, `False` → fail, `None` → not-applicable (passes). Mirrors `version_at_least`'s graceful-degradation pattern.
- Rules are per-variable (`variables/.*/is_contiguous`, `variables/.*/is_zvariable`), ERROR.
- Floor bumped to **`pycdfpp>=0.11.0`** — safe for the web demo: 0.11.0 ships emscripten wheels for both Pyodide ABIs (`cp313/pyemscripten_2025_0` + `cp314/pyemscripten_2026_0`).

## Result

Every representable CDF-A structural requirement is now checked: compression (001/002), version (003), contiguity (004), zVariables (005). The *single-file* requirement is satisfied by construction (AstraLint only loads single-file CDFs). Closes the structural half of #2.

The MMS reference CDF is all-z, contiguous, v3.5.0 → passes 003/004/005 (still flags compression + missing SPASE).

## Tests

`tests/test_pds4_suite.py` extended (fragmented/rVariable fail; contiguous/zVar pass; `None` = not-applicable passes; real-file control). Full suite **408 pass**, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)