### PR TITLE
feat(resolver): PDS4 archive-readiness auto-fix (decompress + defragment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Every proposed fix carries its **source**, **confidence**, and a one-line
   `FILLVAL` set to the ISTP default for the variable's type; `VAR_TYPE`/`DEPEND_0`
   inferred from the variable reference graph; `Logical_file_id`/`Logical_source`
   derived from an ISTP-conventional filename; an out-of-range `FILLVAL` reset to
-  the standard fill; `Generation_date` reformatted to `yyyymmdd`.
+  the standard fill; `Generation_date` reformatted to `yyyymmdd`. For the **PDS4**
+  suite, `astralint fix` also re-saves the CDF uncompressed and contiguous in one
+  lossless step, clearing the CDF-A compression and fragmentation requirements.
 - **staged** — computed but lossy or ambiguous, so it is *suggested* for review and
   never applied automatically. Examples: truncating an over-long
   `CATDESC`/`FIELDNAM`/`LABLAXIS`; a closest-name suggestion for a dangling

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -495,7 +495,7 @@
                 <input type="radio" name="suite" id="suite-pds4" value="PDS4">
                 <label for="suite-pds4">
                     <strong>PDS4</strong><br>
-                    <small>Planetary Data System</small>
+                    <small>PDS4 CDF archiving profile (CDF-A)</small>
                 </label>
                 <input type="radio" name="suite" id="suite-solarnet" value="SOLARNET">
                 <label for="suite-solarnet">

--- a/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
+++ b/docs/superpowers/specs/2026-06-22-pds4-cdfa-rules-design.md
@@ -76,9 +76,17 @@ branches (project convention since the readable-passing-rules work).
 - **No Epoch-name rule.** The CDF-A guide quotes ISTP's older "`DEPEND_0` must equal
   `'Epoch'` / Epoch first variable" text, but the ISTP suite was deliberately made
   name-agnostic (any CDF-time-typed variable is a valid epoch). We do not regress that.
-- **No compression auto-fix.** Producing an uncompressed copy (pycdfpp re-save without
-  compression) is a real future resolver entry but is out of scope here.
-  `spase_DatasetResourceID` stays USER-only — never fabricated (identity/provenance).
+- `spase_DatasetResourceID` stays USER-only — never fabricated (identity/provenance).
+
+### Auto-fix (added 2026-06-23)
+
+The structural failures are auto-fixable losslessly. The resolver emits a single `Fix`
+with `action="normalize"` (source `STRUCTURE`) whenever `PDS4-CDFA-001/002/004` fail;
+`apply._normalize_layout` sets `cdf.compression` + every `var.compression` to
+`no_compression`, and `pycdfpp.save` re-serialises contiguously — so one re-save clears
+compression *and* fragmentation. It is AUTO (lossless), so `astralint fix --suite PDS4`
+produces an archive-ready CDF. Version (CDFA-003) and `spase_DatasetResourceID` are not
+auto-fixed (the former is the writer's, the latter is USER identity).
 
 ## Structural constraints — resolution
 

--- a/src/astralint/resolver/apply.py
+++ b/src/astralint/resolver/apply.py
@@ -39,7 +39,19 @@ def _abstract_type(var) -> DataType:
     return type_mapping.get(var.type, DataType.NONE)
 
 
+def _normalize_layout(cdf) -> None:
+    """Store the CDF uncompressed; re-serialization (pycdfpp.save) also writes each
+    variable's records contiguously, so this clears compression and fragmentation."""
+    cdf.compression = pycdfpp.CompressionType.no_compression
+    for _, var in cdf.items():
+        var.compression = pycdfpp.CompressionType.no_compression
+
+
 def _apply_one(cdf, fix: Fix) -> None:
+    if fix.action == "normalize":
+        _normalize_layout(cdf)
+        return
+
     if fix.scope == Scope.GLOBAL:
         # One CHAR entry: entries_values is a flat list of per-entry values.
         if fix.action == "add":

--- a/src/astralint/resolver/engine.py
+++ b/src/astralint/resolver/engine.py
@@ -1,7 +1,11 @@
 from ..base.file import File
 from ..base.validation_result import Severity, ValidationResultGroup
-from .models import ApplyPolicy, Fix, ResolverEntry, ResolverOutput, Scope
+from .models import ApplyPolicy, Fix, ReferenceSource, ResolverEntry, ResolverOutput, Scope
 from .registry import REGISTRY
+
+# PDS4/CDF-A structural failures all cleared by one lossless re-save (store the CDF
+# uncompressed; pycdfpp.save also writes variables contiguously).
+_NORMALIZE_TRIGGERS = {"PDS4-CDFA-001", "PDS4-CDFA-002", "PDS4-CDFA-004"}
 
 
 def _iter_failures(group: ValidationResultGroup, inherited_reference: str = ""):
@@ -83,6 +87,28 @@ def _build_fix(
     )
 
 
+def _structural_fix(failures: ValidationResultGroup) -> list[Fix]:
+    """A single lossless re-save that clears compression (CDFA-001/002) and
+    fragmentation (CDFA-004). Emitted once when any of those rules fail."""
+    references = {reference for reference, _ in _iter_failures(failures)}
+    if not references & _NORMALIZE_TRIGGERS:
+        return []
+    return [
+        Fix(
+            target_path="compression",
+            variable=None,
+            attribute="compression",
+            scope=Scope.GLOBAL,
+            action="normalize",
+            value="no_compression",
+            source=ReferenceSource.STRUCTURE,
+            confidence=1.0,
+            provenance_note="store the CDF uncompressed and contiguous (PDS4/CDF-A); lossless re-save",
+            auto=True,
+        )
+    ]
+
+
 def resolve(file: File, failures: ValidationResultGroup) -> list[Fix]:
     fixes: dict[str, Fix] = {}  # keyed on target_path for dedup
     for reference, leaf in _iter_failures(failures):
@@ -103,4 +129,4 @@ def resolve(file: File, failures: ValidationResultGroup) -> list[Fix]:
             existing = fixes.get(fix.target_path)
             if existing is None or fix.confidence > existing.confidence:
                 fixes[fix.target_path] = fix
-    return list(fixes.values())
+    return list(fixes.values()) + _structural_fix(failures)

--- a/src/astralint/resolver/models.py
+++ b/src/astralint/resolver/models.py
@@ -15,6 +15,7 @@ class ReferenceSource(str, Enum):  # noqa: UP042
     GRAPH_RULE = "graph_rule"
     FILENAME = "filename_convention"
     FORMAT_RULE = "format_rule"  # deterministic reshaping of an existing value (length/format)
+    STRUCTURE = "structure"  # lossless physical-layout rewrite (decompress / defragment)
     USER = "user"
 
 
@@ -57,7 +58,9 @@ class Fix(BaseModel):
     variable: str | None
     attribute: str
     scope: Scope
-    action: Literal["add", "set"]  # add = missing attr; set = present-but-wrong
+    # add = missing attr; set = present-but-wrong; normalize = lossless structural
+    # rewrite of the whole file (store uncompressed + contiguous), attribute/value unused
+    action: Literal["add", "set", "normalize"]
     value: Any
     source: ReferenceSource
     confidence: float

--- a/tests/test_resolver_pds4.py
+++ b/tests/test_resolver_pds4.py
@@ -1,0 +1,57 @@
+"""PDS4 structural auto-fix: re-save a CDF uncompressed and contiguous (CDF-A)."""
+
+from pathlib import Path
+
+import pycdfpp
+
+from astralint.base.conformance_suite import ConformanceSuite, get_suite
+from astralint.resolver import converge, resolve
+from astralint.resolver.engine import _iter_failures
+from astralint.resolver.loop import _load
+
+RESOURCES = Path(__file__).parent / "resources"
+MMS = RESOURCES / "mms1_asp2_srvy_l1b_stat_00000000_v01.cdf"  # gzip-compressed at file level
+
+
+def pds4() -> ConformanceSuite:
+    s = get_suite("PDS4")
+    assert s is not None
+    return s
+
+
+def _mms_bytes() -> bytes:
+    return MMS.read_bytes()
+
+
+def test_resolve_emits_normalize_fix_for_compressed_cdf():
+    file = _load(_mms_bytes(), MMS.name)
+    results = pds4().run(file)
+    fixes = resolve(file, results.failures_only())
+    normalize = [f for f in fixes if f.action == "normalize"]
+    assert normalize, "a compressed CDF must yield a structural normalize fix"
+    assert normalize[0].auto, "decompression is lossless -> auto"
+    assert normalize[0].disposition == "auto"
+
+
+def test_converge_pds4_produces_uncompressed_contiguous_cdf():
+    report, fixed = converge(_mms_bytes(), pds4(), filename=MMS.name)
+
+    cdf = pycdfpp.load(fixed)
+    assert cdf.compression == pycdfpp.CompressionType.no_compression
+    assert all(v.compression == pycdfpp.CompressionType.no_compression for _, v in cdf.items())
+    assert all(v.is_contiguous() for _, v in cdf.items())
+
+    assert any(f.action == "normalize" for f in report.applied)
+    # the file-compression error must be gone after the fix
+    final = pds4().run(_load(fixed, MMS.name))
+    remaining = {ref for ref, _ in _iter_failures(final)}
+    assert "PDS4-CDFA-001" not in remaining
+
+
+def test_no_normalize_fix_when_not_compressed():
+    """A file with no compression/fragmentation failures gets no structural fix."""
+    _, fixed = converge(_mms_bytes(), pds4(), filename=MMS.name)
+    file = _load(fixed, MMS.name)
+    results = pds4().run(file)
+    fixes = resolve(file, results.failures_only())
+    assert not [f for f in fixes if f.action == "normalize"]


### PR DESCRIPTION
## What

`astralint fix --suite PDS4` now produces an **archive-ready CDF**: it re-saves the file uncompressed and contiguous, clearing the CDF-A structural requirements (`PDS4-CDFA-001` file compression, `PDS4-CDFA-002` variable compression, `PDS4-CDFA-004` fragmentation) in one lossless step.

## How

Compression/fragmentation is a *structural* transform, not the resolver's usual per-attribute mutation, so:

- `Fix.action` gains `"normalize"` and a new `ReferenceSource.STRUCTURE`.
- `resolve()` emits **one** `normalize` fix (not per-leaf) when any of CDFA-001/002/004 fail.
- `apply._normalize_layout` sets `cdf.compression` and every `var.compression` to `no_compression`; `pycdfpp.save` then re-serialises each variable's records contiguously — so the single re-save fixes both compression and fragmentation. Verified data is preserved.
- It's **AUTO** (lossless: decompression and defragmentation don't change values).

Version (`PDS4-CDFA-003`) and `spase_DatasetResourceID` are deliberately **not** auto-fixed — the former is the writing library's, the latter is USER identity (never fabricated).

## Result

```
$ astralint fix mms….cdf --suite PDS4
✓ Wrote corrected CDF to mms….fixed.cdf   # uncompressed, all vars contiguous
```

The output loads back as `no_compression` (file + all variables), all `is_contiguous()`, data intact; `PDS4-CDFA-001` no longer fires. Remaining errors are the irreducible USER ones (spase/DOI/UNITS).

## Tests

`tests/test_resolver_pds4.py` — normalize fix emitted & AUTO for a compressed CDF; `converge` yields an uncompressed/contiguous file with CDFA-001 cleared; no structural fix once clean. Full suite **411 pass**, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)