### PR TITLE
fix(rules): accept NaN FILLVAL on real CDFs (VA-019)

### DIFF
--- a/src/astralint/base/yaml_rules/assertions/compare_to.py
+++ b/src/astralint/base/yaml_rules/assertions/compare_to.py
@@ -25,6 +25,17 @@ _operators = {
 _NO_MATCH_TEMPLATE = "{% if valid %}{{ target or path }} did not match any values (not required){% else %}{{ target or path }} did not match any values{% endif %}"
 
 
+def _scalar(value: object) -> object:
+    """Unwrap a single-element sequence to its scalar. CDF numeric variable
+    attributes load nested (e.g. FILLVAL ``[[nan]]`` -> ``values/0`` is ``[nan]``),
+    and comparing the wrapping lists element-wise defeats the ``FILLVAL != FILLVAL``
+    NaN trick (``[nan] != [nan]`` is False because list equality short-circuits on
+    element identity, unlike scalar ``nan != nan`` which is True)."""
+    while isinstance(value, (list, tuple)) and len(value) == 1:
+        value = value[0]
+    return value
+
+
 class CompareToAssertion(BaseEvaluable):
     model_config = ConfigDict(frozen=True)
     check: Literal["compare_to"] = "compare_to"  # type: ignore[assignment]
@@ -90,7 +101,7 @@ class CompareToAssertion(BaseEvaluable):
             other_value = other_matches[0][1]
             ctx["other_value"] = other_value
             try:
-                passed = _operators[self.operator](value, other_value)
+                passed = _operators[self.operator](_scalar(value), _scalar(other_value))
             except TypeError:
                 passed = False
 

--- a/tests/test_istp_rule_corrections.py
+++ b/tests/test_istp_rule_corrections.py
@@ -352,6 +352,44 @@ def test_fillval_nan_is_allowed():
     assert rule.check(f).valid
 
 
+def test_fillval_nan_allowed_through_real_cdf_roundtrip():
+    """Regression: a NaN FILLVAL must pass VA-019 after a real CDF round-trip.
+
+    The codec loads numeric variable attributes nested (FILLVAL -> ``values/0``
+    is the 1-element list ``[nan]``, not the scalar ``nan``). That turned the
+    ``FILLVAL != FILLVAL`` NaN clause into a list comparison, and ``[nan] != [nan]``
+    is False (list equality short-circuits on element identity), so NaN was wrongly
+    flagged as inside the range. The flat-``values`` unit test above never produced
+    that shape, so it masked the bug; this one exercises the true codec output."""
+    import numpy as np
+    import pycdfpp
+
+    from astralint.codecs.cdf import CdfCodec
+
+    src = Path(__file__).parent / "resources" / "mms1_asp2_srvy_l1b_stat_00000000_v01.cdf"
+    cdf = pycdfpp.load(str(src))
+    target = next(
+        name for name, v in cdf.items() if v.type == pycdfpp.DataType.CDF_REAL4 and not v.is_nrv
+    )
+    for key, value in (("VALIDMIN", 0.0), ("VALIDMAX", 100.0), ("FILLVAL", float("nan"))):
+        arr = np.array([value], dtype=np.float32)
+        if key in cdf[target].attributes:
+            cdf[target].attributes[key].set_value(arr, pycdfpp.DataType.CDF_FLOAT)
+        else:
+            cdf[target].add_attribute(key, arr, pycdfpp.DataType.CDF_FLOAT)
+
+    loaded = CdfCodec.load(bytes(pycdfpp.save(cdf)))
+    assert loaded is not None
+    # the bug condition: values/0 is a nested list, not a scalar
+    assert isinstance(loaded.variables[target].attributes["FILLVAL"].values[0], list)
+
+    # isolate the target variable so an unrelated pre-existing finding
+    # (mms1_asp_stat's full-range UINT1 FILLVAL) doesn't mask the result
+    only_target = loaded.model_copy(update={"variables": {target: loaded.variables[target]}})
+    rule = load_rule("VariableAttributes", "FillvalOutsideRange")
+    assert rule.check(only_target).valid
+
+
 # --- Hard-vs-soft: CDAWeb-required globals ------------------------------------
 
 


### PR DESCRIPTION
A NaN `FILLVAL` produced a **false-positive `ISTP-VA-019`** error on real CDF files.

## Root cause
The CDF codec loads numeric variable attributes **nested** — e.g. in the MMS
resource file `FILLVAL` is `[[-9.99e30]]`, so the rule path `FILLVAL/values/0`
resolves to the 1-element **list** `[nan]`, not the scalar `nan`.

VA-019 detects an allowed NaN fill with the `FILLVAL != FILLVAL` trick. As a
scalar, `nan != nan` is `True`; but as a list, `[nan] != [nan]` is **`False`**
(Python list equality short-circuits on element identity). So a NaN `FILLVAL`
was never recognised as outside `[VALIDMIN, VALIDMAX]`. The `<` / `>` clauses
only worked *by accident* (list comparison is element-wise).

The previous `test_fillval_nan_is_allowed` masked this by constructing a flat
`values=[nan]` that the codec never produces.

## Fix
`compare_to` now unwraps single-element sequences to their scalar before
applying the operator (mirrors the resolver's existing `_scalar` helper). This
fixes NaN and removes the latent list-comparison fragility for the ordering
clauses.

```python
passed = _operators[self.operator](_scalar(value), _scalar(other_value))
```

## Regression test
`test_fillval_nan_allowed_through_real_cdf_roundtrip` round-trips a NaN `FILLVAL`
through the **real codec** (the nested shape) and isolates the target variable.
Verified to fail without the fix and pass with it.

## Scope audit
I checked every assertion that compares resolved values, to make sure this
class of bug is not lurking elsewhere:

| Assertion | Compares | Shape | Exposed |
| --- | --- | --- | --- |
| `compare_to` (VA-019) | numeric FILLVAL vs VALIDMIN/MAX | nested `[x]` | **this fix** |
| `compare_to` (LinkCountConsistency) | int `shape/0` | flat | no (unwrap is a no-op) |
| `comparison` | `VAR_TYPE` (str), `record_variance` (bool) | flat | no |
| `in` / `not_in` | string attrs, enums (`compression`, `data_type`) | flat | no |
| `range` | — | unused | no |
| `relationship` | pointer variable names (str) | flat | no |

Only numeric attribute values nest, and `compare_to` is the only assertion that
compares them. Global and variable **string** attributes load flat, so the
membership/comparison rules are unaffected, and the full ISTP suite runs
crash-free on the resource CDF.

Latent note (not reachable today): `comparison`/`range` lack the `TypeError`
guard `compare_to` has, so a *future* numeric-attribute rule using them could
crash. Happy to harden them in a follow-up if desired.

## Verification
- 412 tests pass (incl. the new regression test and the failing-leaf invariance guard)
- `make lint` clean

Relates to the FILLVAL/NaN clarification in IHDE-Alliance/ISTP_metadata#12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)