### PR TITLE
refactor(rules): crash-proof comparison/range against type/shape mismatch

### DIFF
--- a/src/astralint/base/yaml_rules/assertions/base.py
+++ b/src/astralint/base/yaml_rules/assertions/base.py
@@ -33,6 +33,18 @@ def render_message(template: str, context: dict) -> str:
         return f"[template error: {e}] template: {template}"
 
 
+def unwrap_scalar(value: Any) -> Any:
+    """Unwrap a single-element sequence to its scalar. CDF numeric variable
+    attributes load nested (e.g. FILLVAL ``[[nan]]`` -> ``values/0`` is ``[nan]``),
+    so an assertion comparing such a value would otherwise compare lists: that
+    raises ``TypeError`` against a scalar bound (``[5.0] <= 10``) and defeats the
+    ``FILLVAL != FILLVAL`` NaN trick (``[nan] != [nan]`` is False). Comparing on the
+    unwrapped scalar matches the rule author's intent; a no-op on real scalars."""
+    while isinstance(value, (list, tuple)) and len(value) == 1:
+        value = value[0]
+    return value
+
+
 def build_context(target: str, raw_path: str, value: Any, **extra: Any) -> dict:
     ctx: dict = {"value": value, "path": raw_path, "variable": None, "attribute": None}
     parts = target.split("/")

--- a/src/astralint/base/yaml_rules/assertions/compare_to.py
+++ b/src/astralint/base/yaml_rules/assertions/compare_to.py
@@ -11,6 +11,7 @@ from .base import (
     render_message,
     resolve_path,
     resolve_path_with_captures,
+    unwrap_scalar,
 )
 
 _operators = {
@@ -23,17 +24,6 @@ _operators = {
 }
 
 _NO_MATCH_TEMPLATE = "{% if valid %}{{ target or path }} did not match any values (not required){% else %}{{ target or path }} did not match any values{% endif %}"
-
-
-def _scalar(value: object) -> object:
-    """Unwrap a single-element sequence to its scalar. CDF numeric variable
-    attributes load nested (e.g. FILLVAL ``[[nan]]`` -> ``values/0`` is ``[nan]``),
-    and comparing the wrapping lists element-wise defeats the ``FILLVAL != FILLVAL``
-    NaN trick (``[nan] != [nan]`` is False because list equality short-circuits on
-    element identity, unlike scalar ``nan != nan`` which is True)."""
-    while isinstance(value, (list, tuple)) and len(value) == 1:
-        value = value[0]
-    return value
 
 
 class CompareToAssertion(BaseEvaluable):
@@ -101,7 +91,7 @@ class CompareToAssertion(BaseEvaluable):
             other_value = other_matches[0][1]
             ctx["other_value"] = other_value
             try:
-                passed = _operators[self.operator](_scalar(value), _scalar(other_value))
+                passed = _operators[self.operator](unwrap_scalar(value), unwrap_scalar(other_value))
             except TypeError:
                 passed = False
 

--- a/src/astralint/base/yaml_rules/assertions/comparisons.py
+++ b/src/astralint/base/yaml_rules/assertions/comparisons.py
@@ -4,7 +4,7 @@ from pydantic import ConfigDict
 
 from ...file import File
 from ...validation_result import Severity, ValidationResult
-from .base import BaseAssertion, build_context, clean_target, render_message
+from .base import BaseAssertion, build_context, clean_target, render_message, unwrap_scalar
 
 _yaml_types = int | float | bool | list | str
 
@@ -35,7 +35,10 @@ class ComparisonAssertion(BaseAssertion):
         captures: dict[str, str] | None = None,
     ) -> ValidationResult:
         target = clean_target(path)
-        passed = _operators[self.operator](value, self.value)
+        try:
+            passed = _operators[self.operator](unwrap_scalar(value), self.value)
+        except TypeError:
+            passed = False
         ctx = build_context(
             target,
             path,
@@ -71,7 +74,11 @@ class RangeAssertion(BaseAssertion):
         captures: dict[str, str] | None = None,
     ) -> ValidationResult:
         target = clean_target(path)
-        passed = self.min <= value <= self.max
+        try:
+            scalar = unwrap_scalar(value)
+            passed = self.min <= scalar <= self.max
+        except TypeError:
+            passed = False
         ctx = build_context(
             target, path, value, valid=passed, min=self.min, max=self.max, **(captures or {})
         )

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1773,3 +1773,87 @@ def test_all_of_custom_message_on_success(mock_file):
     assert isinstance(result, ValidationResultGroup)
     assert result.name == "all_of"
     assert len(result.results) == 1
+
+
+# =============================================================================
+# comparison / range hardening: nested-value unwrap + TypeError guard
+# =============================================================================
+
+
+def _file_with_attr(values, dtype):
+    """A one-variable File whose only attribute holds ``values`` (matches the
+    CDF codec, which loads numeric variable attributes nested, e.g. ``[[5.0]]``)."""
+    from astralint.base.file import Attribute, File, Variable
+
+    return File(
+        extension="cdf",
+        filename="t.cdf",
+        compression="NONE",
+        attributes={},
+        variables={
+            "v": Variable(
+                name="v",
+                shape=[1],
+                data_type=dtype,
+                compression="NONE",
+                record_variance=True,
+                attributes={"A": Attribute(name="A", data_type=[dtype], shape=[1], values=values)},
+            )
+        },
+    )
+
+
+def _rule(check_block: str):
+    return YamlRule(
+        **safe_load(
+            f"""
+name: T
+description: d
+url: u
+reference: T-HARDEN
+severity: ERROR
+suite: TEST
+assertions:
+  - path: variables/v/attributes/A/values/0
+{check_block}
+"""
+        )
+    )
+
+
+def test_range_unwraps_nested_numeric_value():
+    """range must compare the scalar of a nested ``[[5.0]]`` value, not raise
+    TypeError on the wrapping list (``0 <= [5.0]`` errors before the unwrap)."""
+    from astralint.base.file import DataType
+
+    f = _file_with_attr([[5.0]], DataType.FLOAT64)
+    rule = _rule("    check: range\n    min: 0\n    max: 10")
+    assert rule.check(f).valid
+
+
+def test_comparison_unwraps_nested_numeric_value():
+    """comparison '=' against a literal must unwrap the nested value first
+    (``[5.0] == 5.0`` is False before the unwrap)."""
+    from astralint.base.file import DataType
+
+    f = _file_with_attr([[5.0]], DataType.FLOAT64)
+    rule = _rule('    check: comparison\n    operator: "="\n    value: 5.0')
+    assert rule.check(f).valid
+
+
+def test_range_does_not_crash_on_incompatible_type():
+    """An incompatible value type yields a graceful failure, not a TypeError that
+    aborts the whole validation run."""
+    from astralint.base.file import DataType
+
+    f = _file_with_attr(["abc"], DataType.CHAR)
+    rule = _rule("    check: range\n    min: 0\n    max: 10")
+    assert not rule.check(f).valid
+
+
+def test_comparison_does_not_crash_on_incompatible_type():
+    from astralint.base.file import DataType
+
+    f = _file_with_attr(["abc"], DataType.CHAR)
+    rule = _rule('    check: comparison\n    operator: "<"\n    value: 5')
+    assert not rule.check(f).valid


### PR DESCRIPTION
Defensive follow-up to #52 (NaN FILLVAL fix).

## Why
`compare_to` already (a) unwraps single-element sequences to a scalar and (b)
wraps its operator in `try/except TypeError`. The `comparison` and `range`
assertions did **neither**:

```python
# comparison
passed = _operators[self.operator](value, self.value)   # no guard
# range
passed = self.min <= value <= self.max                  # no guard
```

So a future rule pointing either assertion at a **numeric attribute value**
(which the CDF codec loads nested, e.g. `[5.0]`) or at a **type-mismatched**
value would raise `TypeError` and abort the entire validation run, instead of
yielding a graceful failed finding.

This is latent today — no current rule exercises it (`comparison` is only used
with `=` on `VAR_TYPE`/`record_variance`; `range` is unused). It is the same
class of bug as #52, hardened proactively.

## Changes
- Promote the unwrap helper to `base.py` as a shared `unwrap_scalar` (was
  `_scalar`, local to `compare_to`); `compare_to` now imports it.
- `comparison` and `range` now `unwrap_scalar` the resolved value and wrap the
  comparison in `try/except TypeError` → graceful `valid=False`.

No behavior change for any existing rule (verified: 416 tests pass, incl. the
full ISTP/PDS4 suites and the failing-leaf invariance guard).

## Tests
4 reproducers in `test_assertions.py`, each verified to fail without the change
(TypeError crash, or wrong equality on a nested value) and pass with it:
- `range`/`comparison` unwrap a nested `[[5.0]]` value
- `range`/`comparison` return a graceful failure on an incompatible-type value

## Verification
- 416 tests pass
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)