### PR TITLE
feat(cli): astralint fix respects config rule selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,16 @@ astralint fix myfile.cdf --apply none
 
 # Choose the output path
 astralint fix myfile.cdf --output corrected.cdf
+
+# Respects the same config as `lint`: ignored / deselected rules are not fixed
+astralint fix myfile.cdf --ignore "ISTP-VA-019"
+astralint fix data.cdf --config-file .astralint.prod.yaml
 ```
+
+`fix` reads the same configuration as `lint` (`.astralint.yaml`,
+`pyproject.toml [tool.astralint]`, and `--suite`/`--select`/`--ignore` overrides):
+a rule excluded via `ignore`/`select` or demoted below `ERROR` via
+`severity_overrides` is neither validated nor proposed for fixing.
 
 Every proposed fix carries its **source**, **confidence**, and a one-line
 **provenance note**, and falls into one of three dispositions:

--- a/src/astralint/astralint.py
+++ b/src/astralint/astralint.py
@@ -301,19 +301,32 @@ def _user_line(fx: Fix) -> str:
 @app.command()
 def fix(
     path: Path,
-    suite: str = "ISTP",
+    suite: str | None = None,
+    select: list[str] | None = None,
+    ignore: list[str] | None = None,
+    config_file: Path | None = None,
     apply: str = "auto",
     output: Path | None = None,
     max_iter: int = 10,
 ):
-    """Propose and (optionally) apply deterministic ISTP fixes to a CDF.
+    """Propose and (optionally) apply deterministic fixes to a CDF.
+
+    Respects the same configuration as `lint` (.astralint.yaml / pyproject
+    [tool.astralint] / CLI overrides): a rule excluded via `ignore`/`select` or
+    demoted below ERROR via `severity_overrides` is neither validated nor fixed.
 
     Parameters
     ----------
     path : Path
         The CDF file to repair.
-    suite : str
-        Conformance suite to validate against. Default "ISTP".
+    suite : str, optional
+        Conformance suite to validate against. Overrides config (default "ISTP").
+    select : list[str], optional
+        Rule patterns to include. Overrides config file.
+    ignore : list[str], optional
+        Rule patterns to exclude from validation and fixing. Overrides config file.
+    config_file : Path, optional
+        Path to a specific config file to use.
     apply : str
         "auto" runs the convergence loop and writes a corrected CDF;
         "none" is a dry run that lists proposed fixes without writing.
@@ -326,15 +339,39 @@ def fix(
     if apply not in ("auto", "none"):
         console.print(f"[red]✗[/] Invalid --apply '{escape(apply)}'; expected 'auto' or 'none'")
         raise SystemExit(1)
-    checker = get_suite(suite)
+
+    cli_overrides: dict = {}
+    if suite:
+        cli_overrides["suite"] = suite
+    if select:
+        cli_overrides["select"] = select
+    if ignore:
+        cli_overrides["ignore"] = ignore
+    cfg = load_config(
+        config_file=config_file, cli_overrides=cli_overrides if cli_overrides else None
+    )
+
+    checker = get_suite(cfg.suite)
     if checker is None:
-        console.print(f"[red]✗[/] Unknown suite '{escape(suite)}'")
+        console.print(f"[red]✗[/] Unknown suite '{escape(cfg.suite)}'")
         raise SystemExit(1)
+
+    if cfg.extra_rules:
+        project_root = find_project_root()
+        load_extra_rules([p if p.is_absolute() else project_root / p for p in cfg.extra_rules])
 
     with open(path, "rb") as f:
         cdf_bytes = f.read()
 
-    convergence, fixed = converge(cdf_bytes, checker, max_iter=max_iter, filename=path.name)
+    convergence, fixed = converge(
+        cdf_bytes,
+        checker,
+        max_iter=max_iter,
+        filename=path.name,
+        select=cfg.select or None,
+        ignore=cfg.ignore or None,
+        severity_overrides=cfg.severity_overrides or None,
+    )
 
     if convergence.applied:
         console.print(f"[bold]Proposed/applied fixes ({len(convergence.applied)}):[/]")

--- a/src/astralint/resolver/loop.py
+++ b/src/astralint/resolver/loop.py
@@ -44,6 +44,8 @@ def converge(
     max_iter: int = 10,
     filename: str | None = None,
     ignore: list[str] | None = None,
+    select: list[str] | None = None,
+    severity_overrides: dict | None = None,
 ) -> tuple[ConvergenceReport, bytes]:
     applied: list[Fix] = []
     iterations = 0
@@ -52,7 +54,9 @@ def converge(
 
     while iterations < max_iter:
         file = _load(cdf_bytes, filename)
-        results = suite.run(file, ignore=ignore)
+        results = suite.run(
+            file, select=select, ignore=ignore, severity_overrides=severity_overrides
+        )
         if not results.has_errors():
             stopped = "converged"
             break
@@ -75,7 +79,9 @@ def converge(
     # Recompute staged suggestions against the FINAL file state so they reflect
     # what still needs review after all auto-fixes (not a stale pre-mutation set).
     final_file = _load(cdf_bytes, filename)
-    final = suite.run(final_file, ignore=ignore)
+    final = suite.run(
+        final_file, select=select, ignore=ignore, severity_overrides=severity_overrides
+    )
     staged = [f for f in resolve(final_file, final.failures_only()) if not f.auto]
     report = ConvergenceReport(
         iterations=iterations,

--- a/tests/test_resolver_cli.py
+++ b/tests/test_resolver_cli.py
@@ -107,3 +107,30 @@ def test_fix_hint_counts_user_disposition():
     file.attributes.pop("DOI", None)
     hint = _fix_hint([(p, file, suite.run(file))])
     assert hint is not None
+
+
+def test_fix_baseline_finds_auto_fixes(capsys):
+    """Baseline: with no ignore, the resource CDF yields auto-applicable fixes."""
+    fix_command(Path(_CDF), apply="none")
+    out = capsys.readouterr().out
+    assert "Proposed/applied fixes" in out
+    assert "remaining_errors=0" not in out  # real errors remain to be fixed
+
+
+def test_fix_respects_ignore_from_cli(capsys):
+    """--ignore reaches the convergence loop: dropping every ISTP rule leaves
+    nothing to fix and nothing failing."""
+    fix_command(Path(_CDF), apply="none", ignore=["ISTP-.*"])
+    out = capsys.readouterr().out
+    assert "No auto-applicable fixes found." in out
+    assert "remaining_errors=0" in out
+
+
+def test_fix_respects_ignore_from_config_file(tmp_path, capsys):
+    """The config file's ignore list reaches `fix` (the config-ignore wiring)."""
+    cfg = tmp_path / ".astralint.yaml"
+    cfg.write_text("suite: ISTP\nignore:\n  - 'ISTP-.*'\n")
+    fix_command(Path(_CDF), apply="none", config_file=cfg)
+    out = capsys.readouterr().out
+    assert "No auto-applicable fixes found." in out
+    assert "remaining_errors=0" in out

--- a/tests/test_resolver_loop.py
+++ b/tests/test_resolver_loop.py
@@ -186,3 +186,16 @@ def test_converge_ignore_none_matches_default():
         explicit_none.remaining_errors,
         explicit_none.converged,
     )
+
+
+def test_converge_select_reaches_suite_run():
+    """select reaches suite.run inside converge: selecting only a non-matching
+    pattern leaves no rules to validate, so the file converges with no fixes."""
+    suite = get_suite("ISTP")
+    assert suite is not None
+    with open(_CDF, "rb") as fh:
+        data = fh.read()
+    report, _ = converge(data, suite, select=["NONEXISTENT-.*"])
+    assert report.converged is True
+    assert report.applied == []
+    assert report.remaining_errors == 0


### PR DESCRIPTION
Closes the "CLI `fix` → config rule-selection" backlog item.

## Problem
`astralint fix` hardcoded `suite="ISTP"` and **never loaded config**. So unlike
`lint`, it validated and auto-fixed rules the user had excluded via
`.astralint.yaml` / `pyproject.toml [tool.astralint]` / `--ignore` / `--select`.
A rule a user deliberately deselected could still be "fixed" — mutating their CDF
against their own configuration.

## Change
- **`fix` is now config-aware**, doing the same `load_config` merge as `lint`:
  honours `--suite` / `--select` / `--ignore` / `--config-file` overrides plus
  `extra_rules`, and threads the resolved rule selection into the convergence loop.
- **`converge()` gains `select` + `severity_overrides`** (alongside the existing
  `ignore`), threaded into both internal `suite.run` calls. A rule excluded via
  `ignore`/`select`, or demoted below `ERROR` via `severity_overrides`, is now
  neither validated nor proposed for fixing.

```bash
astralint fix myfile.cdf --ignore "ISTP-VA-019"
astralint fix data.cdf  --config-file .astralint.prod.yaml
```

No behaviour change without config or flags — `fix` still defaults to the full
ISTP suite. The demo already threads `ignore` through `converge`, so it is
unaffected.

## Tests
- `converge`: `select` reaches `suite.run` (selecting a non-matching pattern →
  converges with no fixes).
- `fix` CLI: ignore via `--ignore`, ignore via a `.astralint.yaml` `config_file`
  (the core wiring), plus a baseline asserting fixes still happen without ignore.
- Verified end-to-end through the real CLI (typer repeatable `--ignore`).

420 tests pass, `make lint` clean. README Auto-fixing section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)